### PR TITLE
Added Configurable logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hardware/DS_Store
 src/DS_Store
 ./DS_Store
 hardware/design files/.DS_Store
+logs/
 .DS_Store
 .pio
 .vscode/launch.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,13 @@
 platform = espressif8266
 board = espmxdevkit
 framework = arduino
+; monitor_speed = 115200
+; build_type = debug
+; monitor_filters = 
+; 	default,   ; Remove typical terminal control codes from input
+;     time,      ; Add timestamp with milliseconds for each new line
+;     log2file,  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+; 	esp8266_exception_decoder ; 
 lib_deps = 
 	paulstoffregen/Time@^1.6.1
 	z01ne/MyAlarm@^1.1.2

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,14 @@
 platform = espressif8266
 board = espmxdevkit
 framework = arduino
-lib_deps =
+lib_deps = 
 	paulstoffregen/Time@^1.6.1
 	z01ne/MyAlarm@^1.1.2
 	knolleary/PubSubClient@^2.8
+	# thijse/ArduinoLog@^1.1.1
+	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+build_flags = 
+	-Isrc/logger
 
 [env:test]
 platform = native

--- a/src/JSON.h
+++ b/src/JSON.h
@@ -27,7 +27,7 @@
  */
 
 void doJSON() {
-  debugln("doJSON>>>");
+  Log.verboseln("doJSON>>>");
   UpdateElectricity();
   UpdateGas();
 }
@@ -44,25 +44,25 @@ bool DomoticzJson(char *idx, int nValue, char *sValue) {
             config_data.domoticzIP, config_data.domoticzPort, idx, nValue,
             sValue);
     // sprintf(debugM, "[HTTP] GET... URL: %s\n", url);
-    // debug(">>JSON: ");
-    // debugln(url);
+    // Log.verbose(">>JSON: ");
+    // Log.verboseln(url);
     http.begin(client, url); // HTTP
     delay(200);
     int httpCode = http.GET();
     // httpCode will be negative on error
     if (httpCode > 0) { // HTTP header has been sent and Server response header
                         // has been handled
-                        // debugff("[HTTP] GET... code: %d\n", httpCode);
+                        // Log.verbose("[HTTP] GET... code: %d\n", httpCode);
       // file found at server
       if (httpCode == HTTP_CODE_OK) {
-        debugln("return httpCode == HTTP_CODE_OK");
+        Log.verboseln("return httpCode == HTTP_CODE_OK");
         // String payload = http.getString();
         retVal = true;
         entitledToSleep = true;
         LastJReport = timestampkaal();
       }
     } else {
-      debugln("return httpCode == ERR");
+      Log.verboseln("return httpCode == ERR");
     }
     http.end();
     return retVal;
@@ -71,9 +71,9 @@ bool DomoticzJson(char *idx, int nValue, char *sValue) {
 }
 
 void UpdateGas() {
-  // debug(gasReceived5min);
-  // debug(gasDomoticz);
-  // debugln(prevGAS);                                    //sends over the gas
+  // Log.verbose(gasReceived5min);
+  // Log.verbose(gasDomoticz);
+  // Log.verboseln(prevGAS);                                    //sends over the gas
   // setting to server(s)
   // if (strncmp(gasReceived5min, prevGAS, sizeof(gasReceived5min)) != 0) {  //
   // if we have a new value, report
@@ -82,8 +82,8 @@ void UpdateGas() {
 
     DomoticzJson(config_data.domoticzGasIdx, 0,
                  gasDomoticz); // gasReceived5min);
-    debug(">> UpdateGas(): ");
-    debugln(gasDomoticz);
+    Log.verbose(">> UpdateGas(): ");
+    Log.verboseln(gasDomoticz);
     strcpy(prevGAS, gasDomoticz); // retain current value for future reference
   }
 }
@@ -94,7 +94,7 @@ void UpdateElectricity() {
           electricityUsedTariff2, electricityReturnedTariff1,
           electricityReturnedTariff2, actualElectricityPowerDeli,
           actualElectricityPowerRet);
-  debug(">> UpdateElectricity(): ");
-  debugln(sValue);
+  Log.verbose(">> UpdateElectricity(): ");
+  Log.verboseln(sValue);
   DomoticzJson(config_data.domoticzEnergyIdx, 0, sValue);
 }

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -43,14 +43,14 @@
 // void mqtt_connect(){
 //   if (!mqtt_client.connected()) {
 //      MqttConnected = false;
-//      debugln("Reconnecting to mqtt broker …");
+//      Log.verboseln("Reconnecting to mqtt broker …");
 //      mqtt_reconnect();
 //   } else MqttConnected = true;
 // }
 
 // void mqtt_reconnect(){
 //   if (millis() > nextMQTTreconnectAttempt) {
-//     debugln("Attempting MQTT connection...");
+//     Log.verboseln("Attempting MQTT connection...");
 //     statusMsg = "Attempting MQTT connection...";
 //     // Create a random client ID
 //     String clientId = "P1 Smart Meter – ";
@@ -58,7 +58,7 @@
 //     // Attempt to connect
 //     if (mqtt_client.connect(HOSTNAME, config_data.mqttUser,
 //     config_data.mqttPass)){
-//       debugln("   connected to broker");
+//       Log.verboseln("   connected to broker");
 //       statusMsg += "   connected to broker";
 //       // Once connected, publish an announcement...
 //       mqtt_client.publish("outTopic", "p1 gateway running");
@@ -66,10 +66,10 @@
 //       mqtt_client.subscribe("inTopic");
 //       MqttConnected = true;
 //     } else {
-//       debug("failed, rc=");
+//       Log.verbose("failed, rc=");
 //       statusMsg += "failed, rc=";
-//       debug(mqtt_client.state());
-//       debugln(" trying again later (non blocking)");
+//       Log.verbose(mqtt_client.state());
+//       Log.verboseln(" trying again later (non blocking)");
 //       statusMsg += " trying again later (non blocking)";
 //       nextMQTTreconnectAttempt = millis() + 15000; // try again in 15 seconds
 //       MqttConnected = false;
@@ -87,63 +87,63 @@ bool mqtt_connect() {
   mqtt_client.setCallback(callback);
   byte i = 0;
   while (!mqtt_client.connected() && (i < 3)) {
-    debugln("Attempting MQTT connection");
+    Log.verboseln("Attempting MQTT connection");
     // Attempt to connect
     boolean ret;
 
     ret = mqtt_client.connect(HOSTNAME, config_data.mqttUser,
                               config_data.mqttPass);
     if (ret) {
-      debugln("Connected to MQTT");
+      Log.verboseln("Connected to MQTT");
       MqttConnected = true;
       mqtt_client.publish("outTopic", "P1 gateway");
       mqtt_client.subscribe("inTopic");
       return true;
     } else {
       MqttConnected = false;
-      debug("Failed MQTT connection, return code:");
+      Log.verbose("Failed MQTT connection, return code:");
 
       int Status = mqtt_client.state();
 
       switch (Status) {
       case -4:
-        debugln("Connection timeout");
+        Log.verboseln("Connection timeout");
         break;
 
       case -3:
-        debugln("Connection lost");
+        Log.verboseln("Connection lost");
         break;
 
       case -2:
-        debugln("Connect failed");
+        Log.verboseln("Connect failed");
         break;
 
       case -1:
-        debugln("Disconnected");
+        Log.verboseln("Disconnected");
         break;
 
       case 1:
-        debugln("Bad protocol");
+        Log.verboseln("Bad protocol");
         break;
 
       case 2:
-        debugln("Bad client ID");
+        Log.verboseln("Bad client ID");
         break;
 
       case 3:
-        debugln("Unavailable");
+        Log.verboseln("Unavailable");
         break;
 
       case 4:
-        debugln("Bad credentials");
+        Log.verboseln("Bad credentials");
         break;
 
       case 5:
-        debugln("Unauthorized");
+        Log.verboseln("Unauthorized");
         break;
       }
       if (i == 2)
-        debugln("Retrying MQTT connection next cycle");
+        Log.verboseln("Retrying MQTT connection next cycle");
       i++;
       delay(1000);
     }
@@ -152,29 +152,29 @@ bool mqtt_connect() {
 }
 
 void callback(char *topic, byte *payload, unsigned int length) {
-  debug("Message arrived [");
-  debug(topic);
-  debug("] ");
+  Log.verbose("Message arrived [");
+  Log.verbose(topic);
+  Log.verbose("] ");
   for (unsigned int i = 0; i < length; i++) {
-    debug((char)payload[i]);
+    Log.verbose("%s", (char)payload[i]);
   }
-  debugln();
+  Log.verboseln("");
 }
 
 // * Send a message to a broker topic
 void send_mqtt_message(const char *topic, char *payload) {
   if (payload[0] == 0)
     return; // nothing to report
-  debug("MQTT Outgoing on > ");
-  debug(topic);
-  debug(" > ");
-  debugln(payload);
+  Log.verbose("MQTT Outgoing on > ");
+  Log.verbose(topic);
+  Log.verbose(" > ");
+  Log.verboseln(payload);
   bool result = mqtt_client.publish(topic, payload, false);
 
   if (!result) {
-    debug("MQTT publish to topic: ");
-    debug(topic);
-    debugln(" failed.");
+    Log.verbose("MQTT publish to topic: ");
+    Log.verbose(topic);
+    Log.verboseln(" failed.");
   }
 }
 
@@ -195,8 +195,8 @@ void mqtt_send_metric(String name, char *metric) {
 
 void MQTT_reporter() {
 #ifdef NEDERLANDS
-  debug2("MQTT reporter: ");
-  debug2ln(actualElectricityPowerRet);
+  Log.verbose("MQTT reporter: ");
+  Log.verboseln(actualElectricityPowerRet);
   if (mqtt_dsmr) {
     mqtt_send_metric("equipmentID", equipmentId);
 

--- a/src/TELNET.h
+++ b/src/TELNET.h
@@ -33,15 +33,15 @@ void setupTelnet() {
 
 void telnetloop() {
   int i;
-  debugln("telnetloop()");
+  Log.verboseln("telnetloop()");
   if (telnet.hasClient()) {
-    debugln("telnet.hasClient()");
+    Log.verboseln("telnet.hasClient()");
     // find free/disconnected spot
     for (i = 0; i < MAX_SRV_CLIENTS; i++)
       if (!telnetClients[i]) { // equivalent to !serverClients[i].connected()
         telnetClients[i] = telnet.accept();
-        debug("New client: index ");
-        debugln(i);
+        Log.verbose("New client: index ");
+        Log.verbose("%d\n", i);
         telnetConnected = true;
         break;
       } else
@@ -53,7 +53,7 @@ void telnetloop() {
       // when out of scope, a WiFiClient will
       // - flush() - all data will be sent
       // - stop() - automatically too
-      debugff("server is busy with %d active connections\n", MAX_SRV_CLIENTS);
+      Log.verbose("server is busy with %d active connections\n", MAX_SRV_CLIENTS);
       // something is wrong. We should not reach MAX_SRV_CLIENTS
       // reboot to clean up things.
       ESP.restart();
@@ -66,13 +66,13 @@ void telnetloop() {
       telnetClients[i].read(buf, 100);
       if (strncmp(buf, "debug", 5) == 0) {
         telnetDebugClient = i; // we have found a debug client
-        debugln("debug port request");
+        Log.verboseln("debug port request");
         telnetDebugConnected = true;
         telnetClients[i].flush();
       }
       if (strncmp(buf, "quit", 4) ==
           0) { // we have found a debug client dropping debug connection
-        debugln("debug port request dropped");
+        Log.verboseln("debug port request dropped");
         telnetDebugConnected = false;
         telnetClients[i].flush();
         telnetClients[i].stop();
@@ -94,7 +94,7 @@ bool telnetStillRunning() {
 }
 
 void TelnetReporter() {
-  debugln("TelnetReporter()");
+  Log.verboseln("TelnetReporter()");
   activetelnets = 0;
   int maxToTcp = 0;
   int i;
@@ -107,52 +107,33 @@ void TelnetReporter() {
         } else {
           maxToTcp = std::min(maxToTcp, afw);
         }
-        debug("[]client ");
-        debug(i);
-        debug(" maxtcp ");
-        debugln(maxToTcp);
+        Log.verbose("[]client ");
+        Log.verbose("%d", i);
+        Log.verbose(" maxtcp ");
+        Log.verbose("%d", maxToTcp);
         activetelnets++;
       } else {
         // warn but ignore congested clients
-        debugln("one client is congested");
+        Log.verboseln("one client is congested");
         telnetClients[i].flush();
         telnetClients[i].stop();
       }
     }
   unsigned int len = datagram.length();
   for (i = 0; i < MAX_SRV_CLIENTS; i++) {
-    debug(">>>>> Client ");
-    debug(String(i));
+    Log.verbose(">>>>> Client ");
+    Log.verbose("%d", i);
     if (telnetClients[i].availableForWrite() >= 1) {
-      debugln(" is available for writing");
+      Log.verboseln(" is available for writing");
       size_t tcp_sent = telnetClients[i].write(datagram.c_str(), len);
       if (tcp_sent != len) {
         statusMsg = String("len mismatch for : " + i);
       }
-      debug("Raw Data Published to Telnet connection: ");
-      debugln(i);
+      Log.verbose("Raw Data Published to Telnet connection: ");
+      Log.verbose("%d\n", i);
       LastTReport = timestampkaal();
     } else
-      debugln(" is not available for writing");
+      Log.verboseln(" is not available for writing");
   }
   yield();
-}
-
-void telnetD(String x) {
-  char buf[128];
-  int len = x.length();
-  x.toCharArray(buf, len);
-  if (telnetClients[telnetDebugClient].availableForWrite() >= 1) {
-    telnetClients[telnetDebugClient].write(buf, len);
-  }
-}
-
-void telnetDLn(String x) {
-  char buf[128];
-  x += "\n\r";
-  int len = x.length();
-  x.toCharArray(buf, len);
-  if (telnetClients[telnetDebugClient].availableForWrite() >= 1) {
-    telnetClients[telnetDebugClient].write(buf, len);
-  }
 }

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -41,7 +41,7 @@
          datagram = "";
          datagramValid = false;
          dataEnd = false;
-       debugln("\n\rStart found!");
+       Log.verboseln("\n\rStart found!");
        state = READING;
        nextUpdateTime = millis() + interval; // set trigger for next round
 
@@ -67,7 +67,7 @@
        datagram += "\r";
        datagram += "\n";
      } else  {
-         debugln("Buffer overflow???");
+         Log.verboseln("Buffer overflow???");
          state = FAULT;
          return;
        }
@@ -75,7 +75,7 @@
      validCRCFound = (strtoul(messageCRC, NULL, 16) == currentCRC);
 
        if(validCRCFound) {
-         debugln("\nVALID CRC FOUND!");
+         Log.verboseln("\nVALID CRC FOUND!");
          state = DONE;
          datagramValid = true;
          dataFailureCount = 0;
@@ -83,7 +83,7 @@
  //      gotPowerReading = true; // we at least got electricty readings. Not all setups have a gas meter attached, so gotGasReading is handled when we actually get gasIds coming in
          return;
        }    else {
-         debugln("\n===INVALID CRC FOUND!===");
+         Log.verboseln("\n===INVALID CRC FOUND!===");
          dataFailureCount++;
          state = FAILURE;
          return;
@@ -96,7 +96,7 @@
      return;
    } //state = reading
 
-   debugln("how did we get here??");
+   Log.verboseln("how did we get here??");
    return;
  }
 
@@ -165,180 +165,180 @@ String readFirstParenthesisVal(int start, int end){
         break;
       case 100:
         readFirstParenthesisVal(i, len).toCharArray(P1timestamp, sizeof(P1timestamp));
-        debug("timestamp: ");
-        debugln(P1timestamp);
+        Log.verbose("timestamp: ");
+        Log.verboseln(P1timestamp);
         break;
 
       case 96140:
         readFirstParenthesisVal(i, len).toCharArray(tariffIndicatorElectricity, sizeof(tariffIndicatorElectricity));
-        debug("tarief: ");
-        debugln(tariffIndicatorElectricity);
+        Log.verbose("tarief: ");
+        Log.verboseln(tariffIndicatorElectricity);
         break;
       case 9611:
         readFirstParenthesisVal(i, len).toCharArray(equipmentId, sizeof(equipmentId));
-        debug("meter id: ");
-        debugln(equipmentId);
+        Log.verbose("meter id: ");
+        Log.verboseln(equipmentId);
         break;
       case 19610:
         readFirstParenthesisVal(i, len).toCharArray(equipmentId2, sizeof(equipmentId2));
-        debug("meter id2: ");
-        debugln(equipmentId2);
+        Log.verbose("meter id2: ");
+        Log.verboseln(equipmentId2);
         break;
       case 9810:
-        debugln("storingen");
+        Log.verboseln("storingen");
         break;
       case 10170: // 1-0:1.7.0 – actualElectricityPowerDelivered
         readUntilStar(i, len).toCharArray(actualElectricityPowerDeli, sizeof(actualElectricityPowerDeli));
-        debug("1-0:1.7.x > ");
-        debugln(actualElectricityPowerDeli);
+        Log.verbose("1-0:1.7.x > ");
+        Log.verboseln(actualElectricityPowerDeli);
         break;
       case 10270: // 1-0:1.7.0 – actualElectricityPowerReturned
         readUntilStar(i, len).toCharArray(actualElectricityPowerRet, sizeof(actualElectricityPowerRet));
-        debug("1-0:2.7.0 > ");
-        debugln(actualElectricityPowerRet);
+        Log.verbose("1-0:2.7.0 > ");
+        Log.verboseln(actualElectricityPowerRet);
         break;
 
       case 10180: // 1-0:1.8.0 – actualElectricityPowerDelivered
-        debug("non existent ");
+        Log.verbose("non existent ");
         readUntilStar(i, len).toCharArray(actualElectricityPowerDeli, sizeof(actualElectricityPowerDeli));
-        debug("1-0:1.7.x > ");
-        debugln(actualElectricityPowerDeli);
+        Log.verbose("1-0:1.7.x > ");
+        Log.verboseln(actualElectricityPowerDeli);
         break;
       case 10181:  // 1-0:1.8.1(000992.992*kWh) Elektra verbruik laag tarief
         readUntilStar(i, len).toCharArray(electricityUsedTariff1, sizeof(electricityUsedTariff1));
-        debug("1-0:1.8.1 > ");
-        debugln(electricityUsedTariff1);
+        Log.verbose("1-0:1.8.1 > ");
+        Log.verboseln(electricityUsedTariff1);
         break;
       case 10182: // 1-0:1.8.2(000560.157*kWh) = Elektra verbruik hoog tarief
         readUntilStar(i, len).toCharArray(electricityUsedTariff2, sizeof(electricityUsedTariff2));
-        debug("1-0:1.8.2 > ");
-        debugln(electricityUsedTariff2);
+        Log.verbose("1-0:1.8.2 > ");
+        Log.verboseln(electricityUsedTariff2);
         break;
       case 10281: // 1-0:2.8.1(000348.890*kWh) Elektra opbrengst laag tarief
         readUntilStar(i, len).toCharArray(electricityReturnedTariff1, sizeof(electricityReturnedTariff1));
-        debug("1-0:2.8.1 > ");
-        debugln(electricityReturnedTariff1);
+        Log.verbose("1-0:2.8.1 > ");
+        Log.verboseln(electricityReturnedTariff1);
         break;
       case 10282: // 1-0:2.8.2(000859.885*kWh) Elektra opbrengst hoog tarief
         readUntilStar(i, len).toCharArray(electricityReturnedTariff2, sizeof(electricityReturnedTariff2));
-        debug("1-0:2.8.2 > ");
-        debugln(electricityReturnedTariff2);
+        Log.verbose("1-0:2.8.2 > ");
+        Log.verboseln(electricityReturnedTariff2);
         break;
 
        case 103170:  // 1-0:31.7.0(002*A) Instantane stroom Elektriciteit L1
         readUntilStar(i, len).toCharArray(instantaneousCurrentL1, sizeof(instantaneousCurrentL1));
-        debug("1-0:31.7.0 > ");
-        debugln(instantaneousCurrentL1);
+        Log.verbose("1-0:31.7.0 > ");
+        Log.verboseln(instantaneousCurrentL1);
         break;
        case 105170:  // 1-0:51.7.0(002*A) Instantane stroom Elektriciteit L2
         readUntilStar(i, len).toCharArray(instantaneousCurrentL2, sizeof(instantaneousCurrentL2));
-        debug("1-0:51.7.0 > ");
-        debugln(instantaneousCurrentL2);
+        Log.verbose("1-0:51.7.0 > ");
+        Log.verboseln(instantaneousCurrentL2);
         break;
        case 107170:  // 1-0:71.7.0(002*A) Instantane stroom Elektriciteit L3
         readUntilStar(i, len).toCharArray(instantaneousCurrentL3, sizeof(instantaneousCurrentL3));
-        debug("1-0:71.7.0 > ");
-        debugln(instantaneousCurrentL3);
+        Log.verbose("1-0:71.7.0 > ");
+        Log.verboseln(instantaneousCurrentL3);
         break;
 
 
        case 103270: // 1-0:32.7.0(232.0*V) Voltage L1
         readUntilStar(i, len).toCharArray(instantaneousVoltageL1, sizeof(instantaneousVoltageL1));
-        debug("1-0:32.7.0 > ");
-        debugln(instantaneousVoltageL1);
+        Log.verbose("1-0:32.7.0 > ");
+        Log.verboseln(instantaneousVoltageL1);
         break;
        case 105270: // 1-0:52.7.0(232.0*V) Voltage L2
         readUntilStar(i, len).toCharArray(instantaneousVoltageL2, sizeof(instantaneousVoltageL2));
-        debug("1-0:32.7.0 > ");
-        debugln(instantaneousVoltageL2);
+        Log.verbose("1-0:32.7.0 > ");
+        Log.verboseln(instantaneousVoltageL2);
         break;
        case 107270: // 1-0:72.7.0(232.0*V) Voltage L3
         readUntilStar(i, len).toCharArray(instantaneousVoltageL3, sizeof(instantaneousVoltageL3));
-        debug("1-0:72.7.0 > ");
-        debugln(instantaneousVoltageL3);
+        Log.verbose("1-0:72.7.0 > ");
+        Log.verboseln(instantaneousVoltageL3);
         break;
 
 
        case 102170:  // 1-0:21.7.0(002*A) Instantane stroom Elektriciteit L1
         readUntilStar(i, len).toCharArray(activePowerL1P, sizeof(activePowerL1P));
-        debug("1-0:21.7.0 > ");
-        debugln(activePowerL1P);
+        Log.verbose("1-0:21.7.0 > ");
+        Log.verboseln(activePowerL1P);
         break;
        case 104170:  // 1-0:41.7.0(002*A) Instantane stroom Elektriciteit L2
         readUntilStar(i, len).toCharArray(activePowerL2P, sizeof(activePowerL2P));
-        debug("1-0:41.7.0 > ");
-        debugln(activePowerL2P);
+        Log.verbose("1-0:41.7.0 > ");
+        Log.verboseln(activePowerL2P);
         break;
       case 106170:  // 1-0:61.7.0(002*A) Instantane stroom Elektriciteit L3
         readUntilStar(i, len).toCharArray(activePowerL3P, sizeof(activePowerL3P));
-        debug("1-0:61.7.0 > ");
-        debugln(activePowerL3P);
+        Log.verbose("1-0:61.7.0 > ");
+        Log.verboseln(activePowerL3P);
         break;
 
        case 102270: // 1-0:22.7.0(232.0*V) Voltage L1
         readUntilStar(i, len).toCharArray(activePowerL1NP, sizeof(activePowerL1NP));
-        debug("1-0:22.7.0 > ");
-        debugln(activePowerL1NP);
+        Log.verbose("1-0:22.7.0 > ");
+        Log.verboseln(activePowerL1NP);
         break;
        case 104270: // 1-0:42.7.0(232.0*V) Voltage L2
         readUntilStar(i, len).toCharArray(activePowerL2NP, sizeof(activePowerL2NP));
-        debug("1-0:42.7.0 > ");
-        debugln(activePowerL2NP);
+        Log.verbose("1-0:42.7.0 > ");
+        Log.verboseln(activePowerL2NP);
         break;
        case 106270: // 1-0:62.7.0(232.0*V) Voltage L3
         readUntilStar(i, len).toCharArray(activePowerL3NP, sizeof(activePowerL3NP));
-        debug("1-0:62.7.0 > ");
-        debugln(activePowerL3NP);
+        Log.verbose("1-0:62.7.0 > ");
+        Log.verboseln(activePowerL3NP);
         break;
 
 
        case 1032320: // Aantal korte spanningsdalingen Elektriciteit in fase 1
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL1, sizeof(numberVoltageSagsL1));
-        debug("1-0:32.32.0 > ");
-        debugln(numberVoltageSagsL1);
+        Log.verbose("1-0:32.32.0 > ");
+        Log.verboseln(numberVoltageSagsL1);
         break;
        case 1052320: // Aantal korte spanningsdalingen Elektriciteit in fase 2
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL2, sizeof(numberVoltageSagsL2));
-        debug("1-0:52.32.0 > ");
-        debugln(numberVoltageSagsL2);
+        Log.verbose("1-0:52.32.0 > ");
+        Log.verboseln(numberVoltageSagsL2);
         break;
        case 1072320: // Aantal korte spanningsdalingen Elektriciteit in fase 3
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL3, sizeof(numberVoltageSagsL3));
-        debug("1-0:72.32.0 > ");
-        debugln(numberVoltageSagsL3);
+        Log.verbose("1-0:72.32.0 > ");
+        Log.verboseln(numberVoltageSagsL3);
         break;
 
        case 1032360: // 1-0:32.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 1
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL1, sizeof(numberVoltageSwellsL1));
-        debug("1-0:32.36.0 > ");
-        debugln(numberVoltageSwellsL1);
+        Log.verbose("1-0:32.36.0 > ");
+        Log.verboseln(numberVoltageSwellsL1);
         break;
        case 1052360: // 1-0:52.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 2
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL2, sizeof(numberVoltageSwellsL2));
-        debug("1-0:52.36.0 > ");
-        debugln(numberVoltageSwellsL2);
+        Log.verbose("1-0:52.36.0 > ");
+        Log.verboseln(numberVoltageSwellsL2);
         break;
        case 1072360: // 1-0:72.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 3
         readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL3, sizeof(numberVoltageSwellsL3));
-        debug("1-0:72.36.0 > ");
-        debugln(numberVoltageSwellsL3);
+        Log.verbose("1-0:72.36.0 > ");
+        Log.verboseln(numberVoltageSwellsL3);
         break;
 
        case 12421: // gas
         readBetweenDoubleParenthesis(i, len).toCharArray(gasReceived5min, sizeof(gasReceived5min));
         readBetweenDoubleParenthesis(i, len).toCharArray(gasDomoticz, sizeof(gasDomoticz));
-        debug("gas: 0-1:24.2.1 > ");
-        debugln(gasReceived5min);
+        Log.verbose("gas: 0-1:24.2.1 > ");
+        Log.verboseln(gasReceived5min);
         break;
       case 96721: // 0-0:96.7.21(00051)  Number of power failures in any phase
         readFirstParenthesisVal(i, len).toCharArray(numberPowerFailuresAny, sizeof(numberPowerFailuresAny));
-        debug("0-0:96.7.21 > ");
-        debugln(numberPowerFailuresAny);
+        Log.verbose("0-0:96.7.21 > ");
+        Log.verboseln(numberPowerFailuresAny);
         break;
       case 9679: // 0-0:96.7.9(00007) Number of long power failures in any phase
         readFirstParenthesisVal(i, len).toCharArray(numberLongPowerFailuresAny, sizeof(numberLongPowerFailuresAny));
-        debug("0-0:96.7.21 > ");
-        debugln(numberLongPowerFailuresAny);
+        Log.verbose("0-0:96.7.21 > ");
+        Log.verboseln(numberLongPowerFailuresAny);
         break;
       case 1099970: //1-0:99.97.0(6) Power Failure Event Log (long power failures)
         longPowerFailuresLog = "";
@@ -348,14 +348,14 @@ String readFirstParenthesisVal(int start, int end){
         }
         break;
       default:
-        debug(" onbekende OBIS: ");
+        Log.verbose(" onbekende OBIS: ");
         statusMsg = "Onbekende OBIS: ";
         while (i < len) {
-          debug((char)telegram[i]);
+          Log.verbose("%s" ,(char)telegram[i]);
           statusMsg += (char)telegram[i];
           i++;
         }
-        debugln();
+        Log.verboseln("");
         break;
     }
       // clear the string for new input:

--- a/src/functions.h
+++ b/src/functions.h
@@ -56,8 +56,8 @@ void RTS_on() {           // switch on Data Request
   digitalWrite(OE, LOW);  // enable buffer
   digitalWrite(DR, HIGH); // turn on Data Request
   OEstate = true;
-  debug("Data request on at ");
-  debugln(millis());
+  Log.verbose("Data request on at ");
+  Log.verbose("%d\n", millis());
 }
 
 void RTS_off() {          // switch off Data Request
@@ -65,10 +65,10 @@ void RTS_off() {          // switch off Data Request
   digitalWrite(OE, HIGH); // put buffer in Tristate mode
   OEstate = false;
   nextUpdateTime = millis() + interval;
-  debug("Data request off at: ");
-  debug(millis());
-  debug(" nextUpdateTime: ");
-  debugln(nextUpdateTime);
+  Log.verbose("Data request off at: ");
+  Log.verbose("%d", millis());
+  Log.verbose(" nextUpdateTime: ");
+  Log.verbose("%d\n", nextUpdateTime);
 }
 
 bool isNumber(char *res, int len) {
@@ -95,7 +95,7 @@ void settime() {
   setTime(NUM(6, 10) + NUM(7, 1), NUM(8, 10) + NUM(9, 1),
           NUM(10, 10) + NUM(11, 1), NUM(4, 10) + NUM(5, 1),
           NUM(2, 10) + NUM(3, 1), NUM(0, 10) + NUM(1, 1));
-  debug(timestamp());
+  Log.verbose("%d", timestamp());
   LastReportinSecs = now();
   timeIsSet = true;
 }
@@ -110,7 +110,7 @@ String timestampkaal() {
 
 void timeIsSet_cb() {
   if (!timeIsSet) {
-    debugln("Time is set, starting timer service.");
+    Log.verboseln("Time is set, starting timer service.");
     timeIsSet = true;
     timerAlarm.startService();
   }
@@ -119,26 +119,26 @@ void timeIsSet_cb() {
 void createToken() {
   char HexList[] = "1234567890ABCDEF";
 
-  debug("Token: ");
+  Log.verbose("Token: ");
   for (int i = 0; i < 16; i++) {
     setupToken[i] = HexList[random(0, 16)];
-    debug(setupToken[i]);
+    Log.verbose("%s\n", setupToken[i]);
   }
-  debugln();
+  Log.verboseln("");
   setupToken[16] = '\0';
 }
 
 void listDir(const char *dirname) {
-  debugff("Listing directory: %s\n", dirname);
+  Log.verbose("Listing directory: %s\n", dirname);
 
   Dir root = FST.openDir(dirname);
 
   while (root.next()) {
     File file = root.openFile("r");
-    debug("  FILE: ");
-    debug(root.fileName());
-    debug("  SIZE: ");
-    debug(file.size());
+    Log.verbose("  FILE: ");
+    Log.verbose("%s", root.fileName());
+    Log.verbose("  SIZE: ");
+    Log.verbose("%d", file.size());
     time_t cr = file.getCreationTime();
     time_t lw = file.getLastWrite();
     file.close();
@@ -156,34 +156,34 @@ void listDir(const char *dirname) {
 }
 
 void readFile(const char *path) {
-  debugff("Reading file: %s\n", path);
-  debugln();
+  Log.verbose("Reading file: %s\n", path);
+  Log.verboseln("");
   File file = FST.open(path, "r");
   if (!file) {
-    debugln("Failed to open file for reading");
+    Log.verboseln("Failed to open file for reading");
     return;
   }
 
-  debugln("Read from file: ");
+  Log.verboseln("Read from file: ");
   while (file.available()) {
-    debug(String((char)file.read()));
+    Log.verbose("%s", String((char)file.read()));
   }
-  debugln();
+  Log.verboseln("");
   file.close();
 }
 
 void writeFile(const char *path, const char *message) {
-  debugff("Writing file: %s\n", path);
+  Log.verbose("Writing file: %s\n", path);
 
   File file = FST.open(path, "w");
   if (!file) {
-    debugln("Failed to open file for writing");
+    Log.verboseln("Failed to open file for writing");
     return;
   }
   if (file.print(message)) {
-    debugln("File written");
+    Log.verboseln("File written");
   } else {
-    debugln("Write failed");
+    Log.verboseln("Write failed");
   }
   delay(2000); // Make sure the CREATE and LASTWRITE times are different
   file.close();
@@ -191,24 +191,24 @@ void writeFile(const char *path, const char *message) {
 
 void appendFile(const char *path, const char *message) {
 
-  debugfff("Appending to file: %s time: %s\n", path, (String)millis());
+  Log.verbose("Appending to file: %s time: %s\n", path, (String)millis());
   char payload[50];
 
   File file = FST.open(path, "a");
   if (!file) {
-    debugln("Failed to open file for appending");
+    Log.verboseln("Failed to open file for appending");
     sprintf(payload, "can't open file %s", path);
     send_mqtt_message("p1wifi/logging", payload);
     return;
   }
   if (file.print(message)) {
-    debug("Message appended: ");
-    debugln(message);
+    Log.verbose("Message appended: ");
+    Log.verboseln(message);
     sprintf(payload, "Append to %s with %s succeeded: %s", path, message,
             string2char(timestampkaal()));
     send_mqtt_message("p1wifi/logging", payload);
   } else {
-    debugln("Append failed");
+    Log.verboseln("Append failed");
     sprintf(payload, "Append to %s with %s failed: %s", path, message,
             string2char(timestampkaal()));
     send_mqtt_message("p1wifi/logging", payload);
@@ -219,21 +219,21 @@ void appendFile(const char *path, const char *message) {
 }
 
 void renameFile(const char *path1, const char *path2) {
-  debugff("Renaming file %s ", path1);
-  debugff("to %s\n", path2);
+  Log.verbose("Renaming file %s ", path1);
+  Log.verbose("to %s\n", path2);
   if (FST.rename(path1, path2)) {
-    debugln("File renamed");
+    Log.verboseln("File renamed");
   } else {
-    debugln("Rename failed");
+    Log.verboseln("Rename failed");
   }
 }
 
 void deleteFile(const char *path) {
-  debugff("Deleting file: %s\n", path);
+  Log.verbose("Deleting file: %s\n", path);
   if (FST.remove(path)) {
-    debugln("File deleted");
+    Log.verboseln("File deleted");
   } else {
-    debugln("Delete failed");
+    Log.verboseln("Delete failed");
   }
 }
 
@@ -263,7 +263,7 @@ void deleteFile(const char *path) {
 //
 //  while ((n + 1) < size){ // && filel.available()) {
 //    ch = file->read();
-//    debug(ch);
+//    Log.verbose(ch);
 //      // Delete CR.
 //      if (ch == '\r') {
 //      continue;
@@ -281,28 +281,28 @@ int numLines(const char *path) {
   int numberOfLines = 0;
   char ch;
 
-  debugln("counting lines in file");
+  Log.verboseln("counting lines in file");
   File file = FST.open(path, "r");
   if (!file) {
-    debugln("Failed to open file for reading");
+    Log.verboseln("Failed to open file for reading");
     return 0;
   }
 
-  debugln("counting lines …");
+  Log.verboseln("counting lines …");
   while (file.available()) {
     ch = file.read();
     if (ch == '\n')
       numberOfLines++;
   }
-  debugln(numberOfLines);
+  Log.verbose("%d\n", numberOfLines);
   file.close();
   return numberOfLines;
 }
 
 boolean MountFS() {
-  debugln("Mount LittleFS");
+  Log.verboseln("Mount LittleFS");
   if (!FST.begin()) {
-    debugln("FST mount failed");
+    Log.verboseln("FST mount failed");
     return false;
   }
   return true;
@@ -331,7 +331,7 @@ static void handleNotFound() {
 }
 
 void zapFiles() {
-  debug("Cleaning out logfiles ... ");
+  Log.verbose("Cleaning out logfiles ... ");
 
   deleteFile("/HourE1.log");
   deleteFile("/HourE2.log");
@@ -381,14 +381,14 @@ void zapFiles() {
   deleteFile("/YearTR.log");
   deleteFile("/YearG.log");
   deleteFile("/YearGc.log");
-  debugln("done.");
+  Log.verboseln("done.");
 }
 
 void zapConfig() {
-  debug("Cleaning out logData files ... ");
+  Log.verbose("Cleaning out logData files ... ");
   deleteFile("/logData.txt");
   deleteFile("/logData-1.txt");
-  debugln("done.");
+  Log.verboseln("done.");
 }
 
 void formatFS() {
@@ -400,7 +400,7 @@ void formatFS() {
   FST.format();
 
   if (!FST.begin()) {
-    debugln("FST mount failed AGAIN");
+    Log.verboseln("FST mount failed AGAIN");
   } else {
     sprintf(payload, "Filesystem formatted at %s",
             string2char(timestampkaal()));
@@ -515,7 +515,7 @@ void identifyMeter() {
   } else
   meterName = String(meterId);
     meternameSet = true;
-  debugln(meterName);
+  Log.verbose("%s\n", meterName);
   }
 }
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -191,7 +191,7 @@ void writeFile(const char *path, const char *message) {
 
 void appendFile(const char *path, const char *message) {
 
-  Log.verbose("Appending to file: %s time: %s\n", path, (String)millis());
+  Log.verboseln("Appending to file: %s time: %d", path, millis());
   char payload[50];
 
   File file = FST.open(path, "a");

--- a/src/graph.h
+++ b/src/graph.h
@@ -78,7 +78,7 @@ void handleGraphMenu() {
 
 void DumpDataFiles() {
   listDir("/");
-  debugln();
+  Log.verboseln("");
 }
 
 void selectGraph() {
@@ -91,14 +91,14 @@ void selectGraph() {
   strncpy(period, server.arg("period").c_str(), server.arg("period").length());
   period[server.arg("period").length()] = '\0';
 
-  debug("Selected graph: ");
-  debugln(switcher);
-  debug("Selected period: ");
-  debugln(period);
+  Log.verbose("Selected graph: ");
+  Log.verboseln(switcher);
+  Log.verbose("Selected period: ");
+  Log.verboseln(period);
 
   if (server.method() == HTTP_POST) {
     //  int switcher = atoi(server.arg("datatype").c_str());
-    debugln(switcher);
+    Log.verboseln(switcher);
     switch (atoi(switcher)) {
     case 1: // delivered T1/T2
       //     theGraph("E1.log", "E2.log", "Elektriciteit gebruik T1",
@@ -207,14 +207,14 @@ void theGraph(const char *type1, const char *type2, String title1,
     //each period uses 7 * 12 bytes
 
   target1 = (int*)&log_data + offset * 84 + measure1 * 12; //
-  debug("Target 1: ");
-  debugln(offset * 84 + measure1 * 12);
+  Log.verbose("Target 1: ");
+  Log.verboseln(offset * 84 + measure1 * 12);
    for (int i = 0; i < 12; i++) {
     startval1[i] = *(target1);
     target1++;
    }
-   debug("value :");
-   debugln(startval1);
+   Log.verbose("value :");
+   Log.verboseln(startval1);
   //target2 = (int*)&log_data + offset * 84 + measure2 * 12; //
 
    int *p;
@@ -234,10 +234,10 @@ void theGraph(const char *type1, const char *type2, String title1,
     p = (int*)&log_data;
 
   */
-  // debug("file1 to read: ");
-  // debugln(path1);
-  // debug("file2 to read: ");
-  // debugln(path2);
+  // Log.verbose("file1 to read: ");
+  // Log.verboseln(path1);
+  // Log.verbose("file2 to read: ");
+  // Log.verboseln(path2);
 
   // https://stackoverflow.com/questions/44159990/how-to-add-a-total-to-a-chart-in-google-charts
 
@@ -255,7 +255,7 @@ void theGraph(const char *type1, const char *type2, String title1,
   }
 
   server.sendContent(str);
-  // debugln(str);
+  // Log.verboseln(str);
 
   // str += F("function getSum(data, column){var total = 0;for (i = 0; i <
   // data.getNumberOfRows(); i++) total = total + data.getValue(i, column);
@@ -265,18 +265,18 @@ void theGraph(const char *type1, const char *type2, String title1,
           "google.visualization.arrayToDataTable([");
   str += label; // F("[\"uur\", \"m^3\"], ");
   server.sendContent(str);
-  // debugln(str);
+  // Log.verboseln(str);
 
   if (!file1) {
-    debugln("Failed to open file for reading");
+    Log.verboseln("Failed to open file for reading");
     server.sendContent("['0', 0],");
-    //    debug("['0', 0], ");
+    //    Log.verbose("['0', 0], ");
   } else {
     while (file1.available()) {
       int l = file1.readBytesUntil('\n', buffer, sizeof(buffer));
       buffer[l] = 0;
       server.sendContent(buffer);
-      //     debugln(buffer);
+      //     Log.verboseln(buffer);
     }
     file1.close();
   }
@@ -295,7 +295,7 @@ void theGraph(const char *type1, const char *type2, String title1,
         "google.visualization.ColumnChart(document.getElementById('Chart1'));");
   str += F("chart.draw(data, options); }");
   server.sendContent(str);
-  // debugln(str);
+  // Log.verboseln(str);
   delay(200);
 
   str = "";
@@ -305,18 +305,18 @@ void theGraph(const char *type1, const char *type2, String title1,
             "google.visualization.arrayToDataTable([");
     str += label; // F("[\"uur\", \"m^3\"], ");
     server.sendContent(str);
-    //  debugln(str);
+    //  Log.verboseln(str);
 
     if (!file2) {
-      debugln("Failed to open file for reading");
+      Log.verboseln("Failed to open file for reading");
       server.sendContent("['0', 0],");
-      debug("['0', 0], ");
+      Log.verbose("['0', 0], ");
     } else {
       while (file2.available()) {
         int l = file2.readBytesUntil('\n', buffer, sizeof(buffer));
         buffer[l] = 0;
         server.sendContent(buffer);
-        debug(str);
+        Log.verbose("%s", str);
       }
       file2.close();
       delay(200);
@@ -335,7 +335,7 @@ void theGraph(const char *type1, const char *type2, String title1,
                "Chart2'));");
     str += F("chart.draw(data, options); }");
     server.sendContent(str);
-    //  debugln(str);
+    //  Log.verboseln(str);
   } // only if we have a second file to display
 
   str = F("</script>");
@@ -363,7 +363,7 @@ void theGraph(const char *type1, const char *type2, String title1,
            "bhome'>Menu</button></form>");
   addFootBare(str);
   server.sendContent(str);
-  //  debugln(str);
+  //  Log.verboseln(str);
   server.sendContent(F(""));
   monitoring = true;
 }
@@ -388,10 +388,10 @@ void calendarGas() {
   str += F("dataTable.addRows([");
 
   server.sendContent(str);
-  // debugln(str);
+  // Log.verboseln(str);
 
   if (!file) {
-    debugln("Failed to open file for reading");
+    Log.verboseln("Failed to open file for reading");
     server.sendContent("[new Date(2023,0,1), 0],");
   } else {
     while (file.available()) {
@@ -416,7 +416,7 @@ void calendarGas() {
 
   addFootBare(str);
   server.sendContent(str);
-  // debugln(str);
+  // Log.verboseln(str);
   server.sendContent(F(""));
 
   monitoring = true;

--- a/src/logger/MQTTPrinter.h
+++ b/src/logger/MQTTPrinter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Print.h>
+#include <PubSubClient.h>
+
+class MQTTPrinter : public Print {
+public:
+  MQTTPrinter(PubSubClient *mqttClient, const char *topic, Print *backupPrinter)
+      : mMQTTClient(NULL), mTopic(topic), mBackupPrinter(backupPrinter) {
+    mMQTTClient = mqttClient;
+    iBuffIndex = 0;
+  };
+
+  size_t write(uint8_t c) override {
+    if (mqtt_client.connected()) {
+      if (c == '\r' || c == '\n') {
+        size_t length = iBuffIndex;
+        bool success = mMQTTClient->publish(mTopic, mBuff.data(), length);
+        std::fill(mBuff.begin(), mBuff.end(), 0);
+        iBuffIndex = 0;
+        if (success) {
+          return length;
+        }
+        return 0;
+      } else {
+        mBuff[iBuffIndex] = c;
+        iBuffIndex += 1;
+      }
+    } else if (mBackupPrinter) {
+      return mBackupPrinter->write(c);
+    }
+
+    return 0;
+  }
+
+private:
+  PubSubClient *mMQTTClient;
+  const char *mTopic;
+  Print *mBackupPrinter;
+  int iBuffIndex;
+  std::array<uint8_t, MQTT_MAX_PACKET_SIZE> mBuff;
+};

--- a/src/logger/TelnetPrinter.h
+++ b/src/logger/TelnetPrinter.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <ArduinoLog.h>
+#include <Print.h>
+#include <WiFiClient.h>
+#include <WiFiServer.h>
+
+#ifndef MAX_TELNET_PRINTER_CLIENTS
+#define MAX_TELNET_PRINTER_CLIENTS 5
+#endif
+
+static WiFiServer telnetServer(24);
+static WiFiClient telnetPrinterClients[MAX_TELNET_PRINTER_CLIENTS];
+
+void logPrinterTelnetloop() {
+  int iClient;
+
+  // Search for new clients and accept those clients
+  if (telnetServer.hasClient()) {
+    Log.verboseln("Telnet has new client");
+    for (iClient = 0; iClient < MAX_TELNET_PRINTER_CLIENTS; iClient++) {
+      WiFiClient telnetClient = telnetPrinterClients[iClient];
+      if (!telnetClient.connected()) {
+        telnetPrinterClients[iClient] = telnetServer.accept();
+        Log.verboseln("TelnetPrinter: New client at index %d", iClient);
+        break;
+      }
+    }
+  }
+
+  // Clear all incoming data. Logger is sending only
+  for (iClient = 0; iClient < MAX_TELNET_PRINTER_CLIENTS; iClient++) {
+    WiFiClient telnetClient = telnetPrinterClients[iClient];
+    telnetClient.flush();
+  }
+}
+
+class TelnetPrinter : public Print {
+public:
+  TelnetPrinter(const int port, Print *backupPrinter)
+      : mBackupPrinter(backupPrinter) {
+    telnetServer.setNoDelay(true);
+    telnetServer.begin(port);
+
+    mTelnetClients = telnetPrinterClients;
+  };
+
+  size_t write(uint8_t c) override {
+    // If there are Telnet clients connected, write to the Telnet clients.
+    // If not, write to the backup printer if exists.
+    if (hasClients()) {
+      return writeAllClients(c);
+    } else if (mBackupPrinter) {
+      return mBackupPrinter->write(c);
+    }
+    return 0;
+  }
+
+private:
+  WiFiClient *mTelnetClients;
+  Print *mBackupPrinter;
+
+  /**
+   * Checks if there are Telnet clients connected and are available for writing.
+   * 
+   * @return bool: true if there are Telnet clients, false otherwise.
+  */
+  bool hasClients() {
+    int iClient;
+    for (iClient = 0; iClient < MAX_TELNET_PRINTER_CLIENTS; iClient++) {
+      WiFiClient telnetClient = mTelnetClients[iClient];
+      if (telnetClient.availableForWrite() > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Writes the same date to all the active Telnet clients.
+   * 
+   * @param c: Data to write.
+   * @return size_t: Total size of the written characters to all clients.
+  */
+  size_t writeAllClients(uint8_t c) {
+    int iClient;
+    size_t totalSize = 0;
+    for (iClient = 0; iClient < MAX_TELNET_PRINTER_CLIENTS; iClient++) {
+      WiFiClient telnetClient = mTelnetClients[iClient];
+      if (telnetClient.availableForWrite() > 0) {
+        totalSize += telnetClient.write(c);
+      }
+    }
+    return totalSize;
+  }
+};

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Print.h>
+
+#define LOG_PRINTER_NULL 0
+#define LOG_PRINTER_SERIAL 1
+#define LOG_PRINTER_TELNET 2
+#define LOG_PRINTER_MQTT 3
+
+#ifndef PRINTER
+#define PRINTER LOG_PRINTER_SERIAL
+#endif
+
+#if PRINTER == LOG_PRINTER_NULL
+#define DISABLE_LOGGING
+#endif
+#if PRINTER == LOG_PRINTER_SERIAL
+#include <HardwareSerial.h>
+#endif
+#if PRINTER == LOG_PRINTER_TELNET
+#include "TelnetPrinter.h"
+#endif
+#if PRINTER == LOG_PRINTER_MQTT
+#include "MQTTPrinter.h"
+#endif
+
+class LogPrinterCreator {
+public:
+  /**
+   * Creates a Print instance corresponding to the given settings.
+   *
+   * @return Pointer to a Print instance.
+   */
+  Print *createLogPrinter() {
+#if PRINTER == LOG_PRINTER_SERIAL
+    mLogPrinter = &Serial;
+#endif
+#if PRINTER == LOG_PRINTER_TELNET
+    mLogPrinter = new TelnetPrinter(24, &Serial);
+#endif
+#if PRINTER == LOG_PRINTER_MQTT
+    mLogPrinter = new MQTTPrinter(&mqtt_client, "p1wifi/logging", &Serial);
+#endif
+    return mLogPrinter;
+  };
+
+private:
+  Print *mLogPrinter;
+};

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -24,6 +24,73 @@
 #include "MQTTPrinter.h"
 #endif
 
+static struct TerminalColors {
+  // https://en.wikipedia.org/wiki/ANSI_escape_code
+  const char *RESET = "\033[0m"; // Reset or normal 
+  
+  // 1-9 Font styles
+  const char *STYLE_BOLD = "\033[1m"; // Bold or increased intensity
+  const char *STYLE_FAINT = "\033[2m"; // Faint, decreased intensity, or dim 
+  const char *STYLE_ITALIC = "\033[2m"; // Not widely supported. Sometimes treated as inverse or blink.[25]
+  
+  const char *FONT_DEFAULT = "\033[10m"; // Primary (default) font 
+
+  // 30–37 Set foreground color 
+  const char *TEXT_BLACK = "\033[30m";
+  const char *TEXT_RED = "\033[31m";
+  const char *TEXT_GREEN = "\033[32m";
+  const char *TEXT_YELLOW = "\033[33m";
+  const char *TEXT_BLUE = "\033[34m";
+  const char *TEXT_MAGENTA = "\033[35m";
+  const char *TEXT_CYAN = "\033[36m";
+  const char *TEXT_WHITE = "\033[37m";
+  const char *TEXT_DEFAULT = "\033[39m"; // DEFAULT
+
+  // 40–47 Set background color 
+  const char *BACK_BLACK = "\033[40m";
+  const char *BACK_RED = "\033[41m";
+  const char *BACK_GREEN = "\033[42m";
+  const char *BACK_YELLOW = "\033[43m";
+  const char *BACK_BLUE = "\033[44m";
+  const char *BACK_MAGENTA = "\033[45m";
+  const char *BACK_CYAN = "\033[46m";
+  const char *BACK_WHITE = "\033[47m";
+  const char *BACK_DEFAUKLT= "\033[49m"; // DEFAULT
+
+  // 90–97  Set bright foreground color 
+  const char *TEXT_ALT_BLACK = "\033[90m";
+  const char *TEXT_ALT_RED = "\033[91m";
+  const char *TEXT_ALT_GREEN = "\033[92m";
+  const char *TEXT_ALT_YELLOW = "\033[93m";
+  const char *TEXT_ALT_BLUE = "\033[94m";
+  const char *TEXT_ALT_MAGENTA = "\033[95m";
+  const char *TEXT_ALT_CYAN = "\033[96m";
+  const char *TEXT_ALT_WHITE = "\033[97m";
+
+  const char *FATAL = "\033[41m\033[37m"; // BACK_RED + TEXT_WHITE;
+  
+  std::map<int, const char *> logLevelToColor{
+      {LOG_LEVEL_SILENT, ""},
+      {LOG_LEVEL_FATAL, FATAL},
+      {LOG_LEVEL_ERROR, TEXT_ALT_RED},
+      {LOG_LEVEL_WARNING, TEXT_ALT_YELLOW},
+      {LOG_LEVEL_INFO, TEXT_ALT_BLUE},
+      {LOG_LEVEL_TRACE, TEXT_ALT_WHITE},
+      {LOG_LEVEL_VERBOSE, ""}};
+
+  const char *getColorFromLogLevel(int logLevel) {
+    return logLevelToColor[logLevel];
+  }
+} terminalColors;
+
+static void printPrefix(Print *_logOutput, int logLevel) {
+  _logOutput->print(terminalColors.getColorFromLogLevel(logLevel));
+}
+
+static void printSuffix(Print *_logOutput, int logLevel) {
+  _logOutput->print(terminalColors.RESET);
+}
+
 class LogPrinterCreator {
 public:
   /**
@@ -34,6 +101,9 @@ public:
   Print *createLogPrinter() {
 #if PRINTER == LOG_PRINTER_SERIAL
     mLogPrinter = &Serial;
+    Log.setPrefix(printPrefix);
+    Log.setSuffix(printSuffix);
+    Log.setShowLevel(false);
 #endif
 #if PRINTER == LOG_PRINTER_TELNET
     mLogPrinter = new TelnetPrinter(24, &Serial);

--- a/src/logging.h
+++ b/src/logging.h
@@ -50,7 +50,7 @@
 void doInitLogVars() {
   char value[12];
   // init all vars on current (first) reading
-  debug("Initialising log vars ... ");
+  Log.verbose("Initialising log vars ... ");
   strcpy(log_data.hourE1, electricityUsedTariff1);
   strcpy(log_data.dayE1, electricityUsedTariff1);
   strcpy(log_data.weekE1, electricityUsedTariff1);
@@ -90,11 +90,11 @@ void doInitLogVars() {
   strcpy(log_data.yearTR, value);
 
   needToInitLogVars = false;
-  debugln("done.");
+  Log.verboseln("done.");
 }
 
 void doInitLogVarsGas() {
-  debugln("Initialising log GAS vars ... ");
+  Log.verboseln("Initialising log GAS vars ... ");
 
   strcpy(log_data.hourG, gasReceived5min);
   strcpy(log_data.dayG, gasReceived5min);
@@ -102,7 +102,7 @@ void doInitLogVarsGas() {
   strcpy(log_data.monthG, gasReceived5min);
   strcpy(log_data.yearG, gasReceived5min);
   needToInitLogVarsGas = false;
-  debugln("done.");
+  Log.verboseln("done.");
 }
 
 void doMinutelyLog() {
@@ -128,7 +128,7 @@ void doHourlyLog() {
   // if (hourFlag) return;
   FST.begin();
 
-  debugff("Hourly log started at %s ... ", timestampkaal());
+  Log.verbose("Hourly log started at %s ... ", timestampkaal());
   char buffer[60];
   char value[13];
 
@@ -178,8 +178,8 @@ void doHourlyLog() {
 
   FST.end();
   hourFlag = true;
-  debugff("completed at %s.", timestampkaal());
-  debugln();
+  Log.verbose("completed at %s.", timestampkaal());
+  Log.verboseln("");
   checkMinute = minute();
   if (MountFS()) {
     char payload[50];
@@ -200,7 +200,7 @@ void doDailyLog() {
    * set flag
    */
   monitoring = false;
-  debug("Dayly log started ... ");
+  Log.verbose("Dayly log started ... ");
 
   String str = "";
   char buffer[60];
@@ -285,7 +285,7 @@ void doDailyLog() {
   deleteFile("/HourG.log");
 
   dayFlag = true;
-  debugln("completed.");
+  Log.verboseln("completed.");
   monitoring = true;
 }
 
@@ -295,7 +295,7 @@ void doWeeklyLog() {
    *   week cur
    *   set flag
    */
-  debug("Weekly log started. It was a Sunday evening ... ");
+  Log.verbose("Weekly log started. It was a Sunday evening ... ");
   String str = "";
   char buffer[55];
   char value[12];
@@ -363,7 +363,7 @@ void doWeeklyLog() {
   strcpy(log_data.weekG, value);
 
   weekFlag = true;
-  debugln("completed.");
+  Log.verboseln("completed.");
 }
 
 void doMonthlyLog() {
@@ -373,7 +373,7 @@ void doMonthlyLog() {
    * set flag
    */
 
-  debug("Monthlyly log started ... ");
+  Log.verbose("Monthlyly log started ... ");
   String str = "";
   char buffer[55];
   char value[12];
@@ -441,7 +441,7 @@ void doMonthlyLog() {
   strcpy(log_data.monthG, value);
 
   monthFlag = true;
-  debugln("completed.");
+  Log.verboseln("completed.");
 }
 
 void doYearlyLog() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,6 @@ power outages, power drops
 
 */
 
-
 #include "Arduino.h"
 #include "prototypes.h"
 void readTelegram();
@@ -163,8 +162,7 @@ String version = "1.2 – NL";
 
 #define GRAPH 1
 #define V3
-#define DEBUG 0 // 2//1//0 1 is on serial only, 2 is serial + telnet,
-#define DEBUG2 0
+#define DEBUG 0 // 2//1//0 1 is on serial only, 2 is telnet,
 #define WIFIPOWERSAFE 0
 
 #define ESMR5 1
@@ -173,57 +171,29 @@ String version = "1.2 – NL";
 const uint32_t wakeTime = 90000;  // stay awake wakeTime millisecs
 const uint32_t sleepTime = 15000; // sleep sleepTime millisecs
 
-#if DEBUG2 == 1
-#define debug2(x) Serial.print(x)
-#define debug2ln(x) Serial.println(x)
-#else
-#define debug2(x)
-#define debug2ln(x)
-#endif
-
 #if DEBUG == 1
 const char *host = "P1test";
 #define BLED LED_BUILTIN
-#define debug(x) Serial.print(x)
-#define debugf(x) Serial.printf(x)
-#define debugff(x, y) Serial.printf(x, y)
-#define debugfff(x, y, z) Serial.printf(x, y, z)
-#define debugln(x) Serial.println(x)
+#define PRINTER LOG_PRINTER_SERIAL
 #elif DEBUG == 2
 const char *host = "P1test";
 #define BLED LED_BUILTIN
-#define debug(x)                                                               \
-  Serial.print(x);                                                             \
-  if (telnetDebugConnected)                                                    \
-  telnetD(String(x))
-#define debugf(x) Serial.printf(x)
-#define debugff(x, y) Serial.printf(x, y)
-#define debugfff(x, y, z) Serial.printf(x, y, z)
-#define debugln(x)                                                             \
-  Serial.println(x);                                                           \
-  if (telnetDebugConnected)                                                    \
-  telnetDLn(String(x))
+#define PRINTER LOG_PRINTER_TELNET
 #elif DEBUG == 3
 const char *host = "P1home";
 #define BLED LED_BUILTIN
-#define debug(x)
-#define debugln(x)
-#define debugf(x)
-#define debugff(x, y)
-#define debugfff(x, y, z)
+#define DISABLE_LOGGING
+#define PRINTER LOG_PRINTER_NULL
 #else
 const char *host = "P1wifi";
 #define BLED LED_BUILTIN
-#define debug(x)
-#define debugln(x)
-#define debugf(x)
-#define debugff(x, y)
-#define debugfff(x, y, z)
+#define DISABLE_LOGGING
+#define PRINTER LOG_PRINTER_NULL
 #endif
 
 #define errorHalt(msg)                                                         \
   {                                                                            \
-    debugln(F(msg));                                                           \
+    Log.verboseln(F(msg));                                                     \
     return;                                                                    \
   }
 
@@ -240,6 +210,7 @@ const char *host = "P1wifi";
 #include "lang.h"
 #include "vars.h"
 
+#include <ArduinoLog.h>
 #include <TZ.h>
 #define MYTZ TZ_Europe_Amsterdam
 #include "MyAlarm.h"
@@ -305,7 +276,14 @@ WiFiClient telnetClients[MAX_SRV_CLIENTS];
 
 ADC_MODE(ADC_VCC); // allows you to monitor the internal VCC level;
 
+#include "logger.h"
+
 void setup() {
+  // Configure logger
+  LogPrinterCreator *logPrinterCreator = new LogPrinterCreator();
+  Print *logPrinter = logPrinterCreator->createLogPrinter();
+  Log.begin(LOG_LEVEL_VERBOSE, logPrinter);
+  // delete logPrinterCreator;
 
   wifiConnectHandler = WiFi.onStationModeGotIP(onWifiConnect);
   wifiDisconnectHandler = WiFi.onStationModeDisconnected(onWifiDisconnect);
@@ -315,8 +293,8 @@ void setup() {
   delay(1);
   pinMode(BLED, OUTPUT);
   Serial.begin(115200);
-  debugln("Serial.begin(115200);");
-  debugln("wifi uit");
+  Log.verboseln("Serial.begin(115200);");
+  Log.verboseln("wifi uit");
   FlashSize = ESP.getFlashChipRealSize();
 
   // Try to read WiFi settings from RTC memory
@@ -343,9 +321,9 @@ void setup() {
                LOW); //  DR low (only goes high when we want to receive data)
 
   blink(2);
-  debugln("Booting");
-  debugln("Done with Cap charging … ");
-  debugln("Let's go …");
+  Log.verboseln("Booting");
+  Log.verboseln("Done with Cap charging … ");
+  Log.verboseln("Let's go …");
   // Start connection WiFi
   // Switch Radio back On
   WiFi.forceSleepWake();
@@ -392,36 +370,36 @@ void setup() {
     // reportInDecimals = false;
   }
 
-  debugln("EEprom read: done");
+  Log.verboseln("EEprom read: done");
   PrintConfigData();
 
   interval = atoi(config_data.interval) * 1000;
-  debug("interval: ");
-  debugln(String(interval));
+  Log.verbose("interval: ");
+  Log.verbose("%d", interval);
 
-  debugln("Trying to connect to your wifi network:");
+  Log.verboseln("Trying to connect to your wifi network:");
   WiFi.mode(WIFI_STA);
   WiFi.begin(config_data.ssid, config_data.password);
   //-----------Now we replace the normally used "WiFi.begin();" with a precedure
-  //using connection data stored by us
+  // using connection data stored by us
   if (rtcValid) {
     // The RTC data was good, make a quick connection
     WiFi.begin(config_data.ssid, config_data.password, rtcData.channel,
                rtcData.ap_mac, true);
-    debugln("RTC wifi quick start.");
+    Log.verboseln("RTC wifi quick start.");
   } else {
     // The RTC data was not valid, so make a regular connection
     WiFi.begin(config_data.ssid, config_data.password);
-    debugln("Regular wifi start.");
+    Log.verboseln("Regular wifi start.");
   }
 
   byte tries = 0;
   while (WiFi.status() != WL_CONNECTED) {
     ToggleLED delay(300);
-    debug("o");
+    Log.verbose("o");
     if (tries++ > 30) {
-      debugln("");
-      debugln("Setting up Captive Portal by the name 'P1_setup'");
+      Log.verboseln("");
+      Log.verboseln("Setting up Captive Portal by the name 'P1_setup'");
       LEDon WiFi.mode(WIFI_AP);
       softAp = WiFi.softAP("P1_Setup", "");
       APtimer = millis();
@@ -429,10 +407,10 @@ void setup() {
       break;
     }
   }
-  debugln("");
-  debugln("Set up wifi, either in STA or AP mode");
+  Log.verboseln("");
+  Log.verboseln("Set up wifi, either in STA or AP mode");
   if (softAp) {
-    debugln("running in AP mode, all handles will be initiated");
+    Log.verboseln("running in AP mode, all handles will be initiated");
     start_webservices();
   }
 
@@ -448,14 +426,14 @@ void setup() {
 
     WiFi.setAutoReconnect(true);
     WiFi.persistent(true);
-    debugln("HTTP server running.");
-    debug("IP address: ");
-    // debugln(WiFi.localIP());
+    Log.verboseln("HTTP server running.");
+    Log.verbose("IP address: ");
+    // Log.verboseln(WiFi.localIP());
 #if WIFIPOWERSAFE == 1
     setRFPower();
 #endif
     wifiSta = true;
-    debugln("wifi running in Sta (normal) mode");
+    Log.verboseln("wifi running in Sta (normal) mode");
     LEDoff
 #ifdef SLEEP_ENABLED
     modemSleep();
@@ -465,40 +443,40 @@ void setup() {
 #endif
 
     // handle Files
-    debug("Mounting file system ... ");
+    Log.verbose("Mounting file system ... ");
     if (!FST.begin()) {
-      debugln("FST mount failed");
-      debug("Formatting file system ... ");
+      Log.verboseln("FST mount failed");
+      Log.verbose("Formatting file system ... ");
       FST.format();
       if (!FST.begin()) {
-        debugln("FST mount failed AGAIN");
+        Log.verboseln("FST mount failed AGAIN");
       } else {
-        debugln("done.");
+        Log.verboseln("done.");
         if (zapfiles)
           zapFiles();
       }
     } else
-      debugln("done.");
+      Log.verboseln("done.");
 
-    debugln("Reading logdata:");
+    Log.verboseln("Reading logdata:");
     File logData = FST.open("/logData.txt", "r");
     if (logData) {
       logData.read((byte *)&log_data, sizeof(log_data) / sizeof(byte));
       logData.close();
     } else {
-      debugln("Failed to open logData.txt for reading");
+      Log.verboseln("Failed to open logData.txt for reading");
       needToInitLogVars = true;
       needToInitLogVarsGas = true;
     }
     if (zapfiles)
       zapFiles();
 
-    // debugln("Something is terribly wrong, no network connection");
+    // Log.verboseln("Something is terribly wrong, no network connection");
     timerAlarm.stopService();
     settimeofday_cb(timeIsSet_cb);
     configTime(MYTZ, "pool.ntp.org");
 
-    debugln("All systems are go...");
+    Log.verboseln("All systems are go...");
     alignToTelegram();
     nextUpdateTime = nextMQTTreconnectAttempt = EverSoOften = TenSecBeat =
         millis();
@@ -508,11 +486,9 @@ void setup() {
         millis() + wakeTime; // we go to sleep wakeTime seconds from now
     datagram.reserve(1500);
     statusMsg.reserve(200);
-  } // WL connected
+  }                // WL connected
   state = WAITING; // signal that we are waiting for a valid start char (aka /)
-
 }
-
 
 void readTelegram() {
   if (Serial.available()) {
@@ -520,47 +496,55 @@ void readTelegram() {
     while (Serial.available()) {
       int len = Serial.readBytesUntil('\n', telegram, MAXLINELENGTH);
       telegram[len] = '\n';
-      telegram[len+1] = 0;
+      telegram[len + 1] = 0;
       ToggleLED
 
-      debug("STATE: ");
-      debug(state);
-      debug(" >> ");
-      for (int i = 0; i <len; i++) debug(telegram[i]);
+          Log.verbose("STATE: ");
+      Log.verbose("%d", state);
+      Log.verbose(" >> ");
+      for (int i = 0; i < len; i++)
+        Log.verbose("%s", telegram[i]);
 
-      decodeLine(len+1);
+      decodeLine(len + 1);
 
-      debug(" << - ");
-      debugln(state);
+      Log.verbose(" << - ");
+      Log.verbose("%d\n", state);
 
-      switch (state){
-        case DISABLED: // should not occur
-          break;
-        case WAITING:
-          currentCRC = 0;
-          break;
-        case READING:
-          break;
-        case CHECKSUM:
-          break;
-        case DONE:
-          Serial.flush();
-          RTS_off();
-          break;
-        case FAILURE:
-          debugln("kicked out of decode loop (invalid CRC or no CRC!)"); // if there is no checksum, (state=Failure && dataEnd)
-          RTS_off();
-          nextUpdateTime = millis() + interval; // set trigger for next round
-          datagram = "";   // empty datagram and
-          telegram[0] = 0; // telegram (probably uncessesary beacuse Serial.ReadBytesUntil will clear telegram buffer)
-          break;
-        case FAULT:
-          debugln("FAULT");
-          statusMsg = ("FAULT in reading data");
-          state = WAITING;
-          break;
-        default:
-          break;
+      switch (state) {
+      case DISABLED: // should not occur
+        break;
+      case WAITING:
+        currentCRC = 0;
+        break;
+      case READING:
+        break;
+      case CHECKSUM:
+        break;
+      case DONE:
+        Serial.flush();
+        RTS_off();
+        break;
+      case FAILURE:
+        Log.verboseln(
+            "kicked out of decode loop (invalid CRC or no CRC!)"); // if there
+                                                                   // is no
+                                                                   // checksum,
+                                                                   // (state=Failure
+                                                                   // &&
+                                                                   // dataEnd)
+        RTS_off();
+        nextUpdateTime = millis() + interval; // set trigger for next round
+        datagram = "";                        // empty datagram and
+        telegram[0] = 0; // telegram (probably uncessesary beacuse
+                         // Serial.ReadBytesUntil will clear telegram buffer)
+        break;
+      case FAULT:
+        Log.verboseln("FAULT");
+        statusMsg = ("FAULT in reading data");
+        state = WAITING;
+        break;
+      default:
+        break;
       }
     }
     LEDoff
@@ -656,11 +640,17 @@ void loop() {
     EverSoOften = millis() + 22000;
   }
 
-  if ((state == FAILURE) && (dataFailureCount == 10)){ // last resort if we get keeping kicked out by bad data
+  if ((state == FAILURE) &&
+      (dataFailureCount ==
+       10)) { // last resort if we get keeping kicked out by bad data
     mqtt_client.disconnect();
     ESP.restart();
   }
   timerAlarm.update();
+
+#if PRINTER == LOG_PRINTER_TELNET
+  logPrinterTelnetloop();
+#endif
 }
 
 #include "JSON.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -282,7 +282,7 @@ void setup() {
   // Configure logger
   LogPrinterCreator *logPrinterCreator = new LogPrinterCreator();
   Print *logPrinter = logPrinterCreator->createLogPrinter();
-  Log.begin(LOG_LEVEL_VERBOSE, logPrinter);
+  Log.begin(LOG_LEVEL_VERBOSE, logPrinter, false);
   // delete logPrinterCreator;
 
   wifiConnectHandler = WiFi.onStationModeGotIP(onWifiConnect);
@@ -321,7 +321,13 @@ void setup() {
                LOW); //  DR low (only goes high when we want to receive data)
 
   blink(2);
-  Log.verboseln("Booting");
+  Log.infoln("Booting");
+  Log.verboseln("Verbose....");
+  Log.traceln("Trace....");
+  Log.infoln("Info....");
+  Log.warningln("Warning....");
+  Log.errorln("Error....");
+  Log.fatalln("Fatal....");
   Log.verboseln("Done with Cap charging … ");
   Log.verboseln("Let's go …");
   // Start connection WiFi
@@ -374,8 +380,7 @@ void setup() {
   PrintConfigData();
 
   interval = atoi(config_data.interval) * 1000;
-  Log.verbose("interval: ");
-  Log.verbose("%d", interval);
+  Log.verboseln("interval: %d", interval);
 
   Log.verboseln("Trying to connect to your wifi network:");
   WiFi.mode(WIFI_STA);
@@ -396,7 +401,7 @@ void setup() {
   byte tries = 0;
   while (WiFi.status() != WL_CONNECTED) {
     ToggleLED delay(300);
-    Log.verbose("o");
+    Log.verbose(".");
     if (tries++ > 30) {
       Log.verboseln("");
       Log.verboseln("Setting up Captive Portal by the name 'P1_setup'");
@@ -427,8 +432,7 @@ void setup() {
     WiFi.setAutoReconnect(true);
     WiFi.persistent(true);
     Log.verboseln("HTTP server running.");
-    Log.verbose("IP address: ");
-    // Log.verboseln(WiFi.localIP());
+    Log.verboseln("IP address: %p", WiFi.localIP());
 #if WIFIPOWERSAFE == 1
     setRFPower();
 #endif
@@ -443,10 +447,10 @@ void setup() {
 #endif
 
     // handle Files
-    Log.verbose("Mounting file system ... ");
+    Log.verboseln("Mounting file system ... ");
     if (!FST.begin()) {
       Log.verboseln("FST mount failed");
-      Log.verbose("Formatting file system ... ");
+      Log.verboseln("Formatting file system ... ");
       FST.format();
       if (!FST.begin()) {
         Log.verboseln("FST mount failed AGAIN");

--- a/src/newMQTT.h
+++ b/src/newMQTT.h
@@ -6,14 +6,14 @@
 // // void mqtt_connect(){
 // //   if (!mqtt_client.connected()) {
 // //      MqttConnected = false;
-// //      debugln("Reconnecting to mqtt broker …");
+// //      Log.verboseln("Reconnecting to mqtt broker …");
 // //      mqtt_reconnect();
 // //   } else MqttConnected = true;
 // // }
 
 // // void mqtt_reconnect(){
 // //   if (millis() > nextMQTTreconnectAttempt) {
-// //     debugln("Attempting MQTT connection...");
+// //     Log.verboseln("Attempting MQTT connection...");
 // //     statusMsg = "Attempting MQTT connection...";
 // //     // Create a random client ID
 // //     String clientId = "P1 Smart Meter – ";
@@ -21,7 +21,7 @@
 // //     // Attempt to connect
 // //     if (mqtt_client.connect(HOSTNAME, config_data.mqttUser,
 // config_data.mqttPass)){
-// //       debugln("   connected to broker");
+// //       Log.verboseln("   connected to broker");
 // //       statusMsg += "   connected to broker";
 // //       // Once connected, publish an announcement...
 // //       mqtt_client.publish("outTopic", "p1 gateway running");
@@ -29,10 +29,10 @@
 // //       mqtt_client.subscribe("inTopic");
 // //       MqttConnected = true;
 // //     } else {
-// //       debug("failed, rc=");
+// //       Log.verbose("failed, rc=");
 // //       statusMsg += "failed, rc=";
-// //       debug(mqtt_client.state());
-// //       debugln(" trying again later (non blocking)");
+// //       Log.verbose(mqtt_client.state());
+// //       Log.verboseln(" trying again later (non blocking)");
 // //       statusMsg += " trying again later (non blocking)";
 // //       nextMQTTreconnectAttempt = millis() + 15000; // try again in 15
 // seconds
@@ -42,27 +42,27 @@
 // // }
 
 // // void callback(char* topic, byte* payload, unsigned int length) {
-// //   debug("Message arrived [");
-// //   debug(topic);
-// //   debug("] ");
+// //   Log.verbose("Message arrived [");
+// //   Log.verbose(topic);
+// //   Log.verbose("] ");
 // //   for (int i = 0; i < length; i++) {
-// //     debug((char)payload[i]);
+// //     Log.verbose((char)payload[i]);
 // //   }
-// //   debugln();
+// //   Log.verboseln();
 // // }
 
 // void mqtt_connect(){
 // byte i = 0;
 //   while (!mqttClient.connected() && (i < 3))
 //   {
-//     debugln("Attempting MQTT connection");
+//     Log.verboseln("Attempting MQTT connection");
 //     // Attempt to connect
 //     boolean ret;
 
 //     ret = mqtt_client.connect(HOSTNAME, config_data.mqttUser,
 //     config_data.mqttPass); if (ret)
 //     {
-//       debugln("Connected to MQTT");
+//       Log.verboseln("Connected to MQTT");
 //       MqttConnected = true;
 //       mqtt_client.publish("outTopic", "P1 gateway");
 //       mqtt_client.subscribe("inTopic");
@@ -71,38 +71,38 @@
 //     else
 //     {
 //       MqttConnected = false;
-//       debug("Failed MQTT connection, return code:");
+//       Log.verbose("Failed MQTT connection, return code:");
 
 //       int Status = mqttClient.state();
 
 //       switch (Status)
 //       {
 //       case -4:
-//         debugln("Connection timeout");
+//         Log.verboseln("Connection timeout");
 //         break;
 
 //       case -3:
-//         debugln("Connection lost");
+//         Log.verboseln("Connection lost");
 //         break;
 
 //       case -2:
-//         debugln("Connect failed");
+//         Log.verboseln("Connect failed");
 //         break;
 
 //       case -1:
-//         debugln("Disconnected");
+//         Log.verboseln("Disconnected");
 //         break;
 
 //       case 1:
-//         debugln("Bad protocol");
+//         Log.verboseln("Bad protocol");
 //         break;
 
 //       case 2:
-//         debugln("Bad client ID");
+//         Log.verboseln("Bad client ID");
 //         break;
 
 //       case 3:
-//         debugln("Unavailable");
+//         Log.verboseln("Unavailable");
 //         break;
 
 //       case 4:
@@ -110,10 +110,10 @@
 //         break;
 
 //       case 5:
-//         debugln("Unauthorized");
+//         Log.verboseln("Unauthorized");
 //         break;
 //       }
-//       if (i == 2) debugln("Retrying MQTT connection next cycle");
+//       if (i == 2) Log.verboseln("Retrying MQTT connection next cycle");
 //       i++;
 //       delay(1000);
 //     }

--- a/src/p1debug.h
+++ b/src/p1debug.h
@@ -28,46 +28,46 @@
 
 void readVoltage() { // read internal VCC
   volts = ESP.getVcc();
-  debugff("The internal VCC reads %1.2f volts\n", volts / 1000);
+  Log.verbose("The internal VCC reads %1.2f volts\n", volts / 1000);
 }
 
 void PrintConfigData() {
-  debug("dataSet : ");
-  debugln(config_data.dataSet);
-  debug("Admin password : ");
-  debugln(config_data.adminPassword);
-  debug("SSID : ");
-  debugln(config_data.ssid);
-  debug("password : ");
-  debugln(config_data.password);
-  debug("DomoticxIP : ");
-  debugln(config_data.domoticzIP);
-  debug("DomoticzPort : ");
-  debugln(config_data.domoticzPort);
-  debug("domotixzGasIdx : ");
-  debugln(config_data.domoticzGasIdx);
-  debug("domotixzEnergyIdx : ");
-  debugln(config_data.domoticzEnergyIdx);
+  Log.verbose("dataSet : ");
+  Log.verboseln(config_data.dataSet);
+  Log.verbose("Admin password : ");
+  Log.verboseln(config_data.adminPassword);
+  Log.verbose("SSID : ");
+  Log.verboseln(config_data.ssid);
+  Log.verbose("password : ");
+  Log.verboseln(config_data.password);
+  Log.verbose("DomoticxIP : ");
+  Log.verboseln(config_data.domoticzIP);
+  Log.verbose("DomoticzPort : ");
+  Log.verboseln(config_data.domoticzPort);
+  Log.verbose("domotixzGasIdx : ");
+  Log.verboseln(config_data.domoticzGasIdx);
+  Log.verbose("domotixzEnergyIdx : ");
+  Log.verboseln(config_data.domoticzEnergyIdx);
 
-  debug("mqttIP : ");
-  debugln(config_data.mqttIP);
-  debug("mqttPort : ");
-  debugln(config_data.mqttPort);
-  debug("mqttUser : ");
-  debugln(config_data.mqttUser);
-  debug("mqttPass : ");
-  debugln(config_data.mqttPass);
-  debug("mqttTopic : ");
-  debugln(config_data.mqttTopic);
+  Log.verbose("mqttIP : ");
+  Log.verboseln(config_data.mqttIP);
+  Log.verbose("mqttPort : ");
+  Log.verboseln(config_data.mqttPort);
+  Log.verbose("mqttUser : ");
+  Log.verboseln(config_data.mqttUser);
+  Log.verbose("mqttPass : ");
+  Log.verboseln(config_data.mqttPass);
+  Log.verbose("mqttTopic : ");
+  Log.verboseln(config_data.mqttTopic);
 
-  debug("interval : ");
-  debugln(config_data.interval);
-  debug("json : ");
-  debugln(config_data.domo);
-  debug("mqtt : ");
-  debugln(config_data.mqtt);
-  debug("watt : ");
-  debugln(config_data.watt);
-  debug("telnet : ");
-  debugln(config_data.telnet);
+  Log.verbose("interval : ");
+  Log.verboseln(config_data.interval);
+  Log.verbose("json : ");
+  Log.verboseln(config_data.domo);
+  Log.verbose("mqtt : ");
+  Log.verboseln(config_data.mqtt);
+  Log.verbose("watt : ");
+  Log.verboseln(config_data.watt);
+  Log.verbose("telnet : ");
+  Log.verboseln(config_data.telnet);
 }

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -93,8 +93,6 @@ void setupTelnet();
 void telnetloop();
 bool telnetStillRunning();
 void TelnetReporter();
-void telnetD(String x);
-void telnetDLn(String x);
 
 // webserver.h
 void addHead(String &str, int refresh);

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -132,7 +132,7 @@ void addUptime(String &str) {
 }
 
 void handleRoot() {
-  debugln("handleRoot");
+  Log.verboseln("handleRoot");
   String str = "";
   addHead(str, 0);
   addIntro(str);
@@ -158,15 +158,15 @@ void handleRoot() {
 }
 
 void handleSetupSave() {
-  debugln("handleSetupSave");
-  debug("Server args: ");
-  debugln(server.args());
-  debugln(server.arg("plain"));
+  Log.verboseln("handleSetupSave");
+  Log.verbose("Server args: ");
+  Log.verbose("%d\n", server.args());
+  Log.verbose("%d\n", server.arg("plain"));
 
   if (server.args() == 0) {
-    debugln("lege submit, dus redirect naar handleRoot");
+    Log.verboseln("lege submit, dus redirect naar handleRoot");
     handleRoot();
-    debugln("En terug naar mainloop");
+    Log.verboseln("En terug naar mainloop");
     return;
   }
 
@@ -174,10 +174,10 @@ void handleSetupSave() {
 
   if (server.method() == HTTP_POST) {
     if (strncmp(setupToken, server.arg("setuptoken").c_str(), 16) != 0) {
-      debug("Error: non matching tokens: ");
-      debug(setupToken);
-      debug(" -> returned: ");
-      debugln(server.arg("setuptoken"));
+      Log.verbose("Error: non matching tokens: ");
+      Log.verbose("%s", setupToken);
+      Log.verbose(" -> returned: ");
+      Log.verbose("%s\n", server.arg("setuptoken"));
       return;
     }
 
@@ -282,11 +282,11 @@ void handleSetupSave() {
 
 void handleLogin() {
   createToken();
-  debugln("handleLogin");
+  Log.verboseln("handleLogin");
 
   if (millis() < 120000) {
-    debug(millis());
-    debugln(" – You made it within the timeframe, go to setup without login.");
+    Log.verbose("%d", millis());
+    Log.verboseln(" – You made it within the timeframe, go to setup without login.");
     bootSetup = true; // our ticket to handleSetup
     handleSetup();
   }
@@ -309,7 +309,7 @@ void handleLogin() {
 
 void handleUpdateLogin() {
   createToken();
-  debugln("handleUpdateLogin");
+  Log.verboseln("handleUpdateLogin");
 
   String str = "";
   addHead(str, 0);
@@ -331,7 +331,7 @@ void handleUpdateLogin() {
 void handleUploadForm() {
   if (strcmp(server.arg("adminPassword").c_str(), config_data.adminPassword) !=
       0) { // passwords don't match
-    debugln("Error: update entered with wrong password");
+    Log.verboseln("Error: update entered with wrong password");
     errorLogin("Update");
     return;
   } else
@@ -355,7 +355,7 @@ void handleUploadForm() {
 }
 
 void errorLogin(String returnpage) {
-  debugln("errorLogin");
+  Log.verboseln("errorLogin");
   String str = "";
   addHead(str, 0);
   addIntro(str);

--- a/src/webserverNL.h
+++ b/src/webserverNL.h
@@ -2,19 +2,19 @@
 
 void handleSetup() {
   if (millis() > 300000) { // if we did not get here 5 mins after startup, check credentials
-    debugln("indirect call");
+    Log.verboseln("indirect call");
     if (strcmp(server.arg("adminPassword").c_str(),
                config_data.adminPassword) != 0) { // passwords don't match
-      debugln("Error: handlesetup entered with wrong password");
+      Log.verboseln("Error: handlesetup entered with wrong password");
       errorLogin("Setup");
       return;
     }
   }
-  debugln("direct call");
+  Log.verboseln("direct call");
   // monitoring = false; // stop monitoring data
 
   String str = "";
-  debugln("handleSetupForm");
+  Log.verboseln("handleSetupForm");
 
   addHead(str, 0);
   addIntro(str);
@@ -128,11 +128,11 @@ void handleSetup() {
 }
 
 void handleP1() {
-  debug2("handleP1: actualElectricityPowerRet: ");
-  debug2ln(actualElectricityPowerRet);
-  debug2("handleP1: actualElectricityPowerDeli: ");
-  debug2ln(actualElectricityPowerDeli);
-  debugln("handleP1");
+  Log.verbose("handleP1: actualElectricityPowerRet: ");
+  Log.verboseln(actualElectricityPowerRet);
+  Log.verbose("handleP1: actualElectricityPowerDeli: ");
+  Log.verboseln(actualElectricityPowerDeli);
+  Log.verboseln("handleP1");
   String str = "";
   String eenheid, eenheid2, eenheid3;
   if (reportInDecimals)
@@ -191,10 +191,10 @@ void handleP1() {
   str += eenheid;
   str += "</div></p>";
 
-  debug2("buildpage: actualElectricityPowerRet: ");
-  debug2ln(actualElectricityPowerRet);
-  debug2("handleP1: actualElectricityPowerDeli: ");
-  debug2ln(actualElectricityPowerDeli);
+  Log.verbose("buildpage: actualElectricityPowerRet: ");
+  Log.verboseln(actualElectricityPowerRet);
+  Log.verbose("handleP1: actualElectricityPowerDeli: ");
+  Log.verboseln(actualElectricityPowerDeli);
 
   str += "<p><div class='row'><b>Actueel verbruik</b><input type='text' "
          "class='form-control c6' value='";
@@ -288,13 +288,13 @@ void handleP1() {
 
 void handleRawData() {
   String str;
-  debugln("Raw data requested. Here you go.");
+  Log.verboseln("Raw data requested. Here you go.");
   str = "<html><head></head><body>";
   str += datagram;
   str += "</body></html>";
   if (dataEnd) {
     server.send(200, "text/html", str);
-    debugln(datagram);
+    Log.verbose("%s\n", datagram);
   }
 }
 

--- a/src/wifi_functions.h
+++ b/src/wifi_functions.h
@@ -29,8 +29,7 @@ void setRFPower() {
 }
 
 void modemSleep() {
-  Log.verbose("modemSleep: ");
-  Log.verbose("%d\n", millis() / 1000);
+  Log.infoln("modemSleep: %d", millis() / 1000);
   //  stop_services();
   WiFi.shutdown(WiFistate);
   ESP.rtcUserMemoryWrite(RTC_config_data_SLOT_WIFI_STATE,
@@ -44,14 +43,13 @@ void modemSleep() {
 }
 
 void modemWake() {
-  Log.verbose("modemWake: ");
-  Log.verbose("%d\n", millis() / 1000);
+  Log.infoln("modemWake: %d", millis() / 1000);
   ESP.rtcUserMemoryRead(RTC_config_data_SLOT_WIFI_STATE,
                         reinterpret_cast<uint32_t *>(&WiFistate),
                         sizeof(WiFistate));
   if (!WiFi.resumeFromShutdown(WiFistate) ||
       (WiFi.waitForConnectResult(10000) != WL_CONNECTED)) {
-    Serial.println("Cannot resume WiFi connection, connecting via begin...");
+    Log.warningln("Cannot resume WiFi connection, connecting via begin...");
     WiFi.persistent(false);
     wifiReconnect();
   } else {
@@ -65,13 +63,13 @@ void modemWake() {
 }
 
 void wifiReconnect() {
-  Log.verboseln("Trying to connect to your wifi network:");
+  Log.verbose("Trying to connect to your wifi network: ");
   WiFi.mode(WIFI_STA);
   WiFi.begin(config_data.ssid, config_data.password);
   byte tries = 0;
   while (WiFi.status() != WL_CONNECTED) {
     ToggleLED delay(500);
-    Log.verbose("o");
+    Log.verbose(".");
     if (tries++ > 30) {
       Log.verboseln("");
       Log.verboseln("Something is terribly wrong, can't connect to wifi (anymore).");
@@ -79,6 +77,7 @@ void wifiReconnect() {
       ESP.reset();
     }
   }
+  Log.verboseln("");
 }
 
 const char *serverIndex =
@@ -191,13 +190,12 @@ void stop_services() {
 }
 
 void onWifiConnect(const WiFiEventStationModeGotIP &event) {
-  Log.verboseln("Connected to Wi-Fi sucessfully.");
-  Log.verbose("IP address: ");
-  Log.verboseln(WiFi.localIP());
+  Log.infoln("Connected to Wi-Fi sucessfully.");
+  Log.infoln("IP address: %p", WiFi.localIP());
 }
 
 void onWifiDisconnect(const WiFiEventStationModeDisconnected &event) {
-  Log.verboseln("Disconnected from Wi-Fi, trying to connect...");
+  Log.infoln("Disconnected from Wi-Fi, trying to connect...");
   WiFi.disconnect();
   if (rtcValid)
     WiFi.begin(config_data.ssid, config_data.password, rtcData.channel,
@@ -228,6 +226,5 @@ void calcSleeptime() {
     time_to_sleep = millis() + wakeTime;
     break;
   }
-  Log.verbose("Scheduled shutdown at: ");
-  Log.verbose("%d\n", time_to_sleep);
+  Log.verboseln("Scheduled shutdown at: %d", time_to_sleep);
 }


### PR DESCRIPTION
Uses [ArdionoLog](https://reference.arduino.cc/reference/en/libraries/arduinolog/) library for logging.

It can send logs to:
- NULL (disables logging and removes if from the build to reduce the size)
- Serial
- Telnet (port 24, with up to 5 active sessions) - Serial will be used when there is no active connection
- MQTT server (`p1wifi/logging` topic) - Serial will be used when there is no active connection


All `debug` statements are replaced with `Log.verbose`. Later different levels of logging can be used.
```
* 0 - LOG_LEVEL_SILENT     no output 
* 1 - LOG_LEVEL_FATAL      fatal errors 
* 2 - LOG_LEVEL_ERROR      all errors  
* 3 - LOG_LEVEL_WARNING    errors, and warnings 
* 4 - LOG_LEVEL_NOTICE     errors, warnings and notices 
* 5 - LOG_LEVEL_TRACE      errors, warnings, notices & traces 
* 6 - LOG_LEVEL_VERBOSE    all 
```

String can be formatted with variables:
```
* %s	display as string (char*)
* %S    display as string from flash memory (__FlashStringHelper* or char[] PROGMEM)
* %c	display as single character
* %C    display as single character or as hexadecimal value (prefixed by `0x`) if not a printable character
* %d	display as integer value
* %l	display as long value
* %u	display as unsigned long value
* %x	display as hexadecimal value
* %X	display as hexadecimal value prefixed by `0x` and leading zeros
* %b	display as binary number
* %B	display as binary number, prefixed by `0b`
* %t	display as boolean value "t" or "f"
* %T	display as boolean value "true" or "false"
* %D,%F display as double value
* %p    display a  printable object 
```

NOTE: The published ArdionoLog version 1.1.1 is broken (does not remove logging from build), therefore the newer (unreleased) commit on Github is used.