### PR TITLE
P1 data to struct

### DIFF
--- a/src/JSON.h
+++ b/src/JSON.h
@@ -70,29 +70,26 @@ bool DomoticzJson(char *idx, int nValue, char *sValue) {
 }
 
 void UpdateGas() {
-  // Log.verbose(gasReceived5min);
-  // Log.verbose(gasDomoticz);
-  // Log.verboseln(prevGAS);                                    //sends over the gas
-  // setting to server(s)
-  // if (strncmp(gasReceived5min, prevGAS, sizeof(gasReceived5min)) != 0) {  //
+  // sends over the gas setting to server(s)
   // if we have a new value, report
-  if (strncmp(gasDomoticz, prevGAS, sizeof(gasDomoticz)) !=
-      0) { // if we have a new value, report
-
+  if (!dsmrData.gas_delivered.equals(prevGAS)) {
     DomoticzJson(config_data.domoticzGasIdx, 0,
-                 gasDomoticz); // gasReceived5min);
+                 (char *)dsmrData.gas_delivered.c_str());
     Log.verbose(">> UpdateGas(): ");
-    Log.verboseln(gasDomoticz);
-    strcpy(prevGAS, gasDomoticz); // retain current value for future reference
+    Log.verboseln(dsmrData.gas_delivered.c_str());
+    // retain current value for future reference
+    prevGAS = dsmrData.gas_delivered;
   }
 }
 
 void UpdateElectricity() {
   char sValue[300];
-  sprintf(sValue, "%s;%s;%s;%s;%s;%s", electricityUsedTariff1,
-          electricityUsedTariff2, electricityReturnedTariff1,
-          electricityReturnedTariff2, actualElectricityPowerDeli,
-          actualElectricityPowerRet);
+  snprintf(sValue, 300, "%.3f;%.3f;%.3f;%.3f;%.3f;%.3f",
+          dsmrData.energy_delivered_tariff1.val(),
+          dsmrData.energy_delivered_tariff2.val(),
+          dsmrData.energy_returned_tariff1.val(),
+          dsmrData.energy_returned_tariff2.val(),
+          dsmrData.power_delivered.val(), dsmrData.power_returned.val());
   Log.verbose(">> UpdateElectricity(): ");
   Log.verboseln(sValue);
   DomoticzJson(config_data.domoticzEnergyIdx, 0, sValue);

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -188,237 +188,141 @@ void send_metric(String name, float metric) // added *long
   send_mqtt_message(mtopic.c_str(), value); // output
 }
 
-void mqtt_send_metric(String name, char *metric) {
+void send_metric(String name, double metric) // added *long
+{
+  char value[20];
+  dtostrf(metric, 3, 3, value);
+  //  output ftoa(metric, output, 3);
+
   mtopic = String(config_data.mqttTopic) + "/" + name;
-  send_mqtt_message(mtopic.c_str(), metric);
+  send_mqtt_message(mtopic.c_str(), value); // output
+}
+
+void send_metric(String name, uint32_t metric) // added *long
+{
+  char value[6];
+  sprintf(value, "%u", metric);
+  send_mqtt_message(mtopic.c_str(), value); // output
+}
+
+void send_metric(String name, String metric) // added *long
+{
+  send_metric(mtopic, metric.c_str()); // output
+}
+
+void send_metric(String name, FixedValue metric) // added *long
+{
+  send_metric(mtopic, String(metric.val())); // output
+}
+
+void send_metric(String name, const char *metric) {
+  mtopic = String(config_data.mqttTopic) + "/" + name;
+  send_mqtt_message(mtopic.c_str(), (char *)metric);
 }
 
 void MQTT_reporter() {
 #ifdef NEDERLANDS
   Log.verbose("MQTT reporter: ");
-  Log.verboseln(actualElectricityPowerRet);
+  Log.verboseln("%F", dsmrData.power_returned.val());
   if (mqtt_dsmr) {
-    mqtt_send_metric("equipmentID", equipmentId);
+    send_metric("equipmentID", dsmrData.equipment_id);
 
-    mqtt_send_metric("reading/electricity_delivered_1", electricityUsedTariff1);
-    mqtt_send_metric("reading/electricity_delivered_2", electricityUsedTariff2);
-    mqtt_send_metric("reading/electricity_returned_1",
-                     electricityReturnedTariff1);
-    mqtt_send_metric("reading/electricity_returned_2",
-                     electricityReturnedTariff2);
-    mqtt_send_metric("reading/electricity_currently_delivered",
-                     actualElectricityPowerDeli);
-    mqtt_send_metric("reading/electricity_currently_returned",
-                     actualElectricityPowerRet);
+    send_metric("reading/electricity_delivered_1", dsmrData.energy_delivered_tariff1);
+    send_metric("reading/electricity_delivered_2", dsmrData.energy_delivered_tariff2);
+    send_metric("reading/electricity_returned_1", dsmrData.energy_returned_tariff1);
+    send_metric("reading/electricity_returned_2", dsmrData.energy_returned_tariff2);
+    send_metric("reading/electricity_currently_delivered", dsmrData.power_delivered);
+    send_metric("reading/electricity_currently_returned", dsmrData.power_returned);
 
-    mqtt_send_metric("reading/phase_currently_delivered_l1", activePowerL1P);
-    mqtt_send_metric("reading/phase_currently_delivered_l2", activePowerL2P);
-    mqtt_send_metric("reading/phase_currently_delivered_l3", activePowerL3P);
-    mqtt_send_metric("reading/phase_currently_returned_l1", activePowerL1NP);
-    mqtt_send_metric("reading/phase_currently_returned_l2", activePowerL2NP);
-    mqtt_send_metric("reading/phase_currently_returned_l3", activePowerL3NP);
-    mqtt_send_metric("reading/phase_voltage_l1", instantaneousVoltageL1);
-    mqtt_send_metric("reading/phase_voltage_l2", instantaneousVoltageL2);
-    mqtt_send_metric("reading/phase_voltage_l3", instantaneousVoltageL3);
+    send_metric("reading/phase_currently_delivered_l1", dsmrData.power_delivered_l1);
+    send_metric("reading/phase_currently_delivered_l2", dsmrData.power_delivered_l2);
+    send_metric("reading/phase_currently_delivered_l3", dsmrData.power_delivered_l3);
+    send_metric("reading/phase_currently_returned_l1", dsmrData.power_returned_l1);
+    send_metric("reading/phase_currently_returned_l2", dsmrData.power_returned_l2);
+    send_metric("reading/phase_currently_returned_l3", dsmrData.power_returned_l3);
+    send_metric("reading/phase_voltage_l1", dsmrData.voltage_l1);
+    send_metric("reading/phase_voltage_l2", dsmrData.voltage_l2);
+    send_metric("reading/phase_voltage_l3", dsmrData.voltage_l3);
 
-    mqtt_send_metric("consumption/gas/delivered", gasReceived5min);
+    send_metric("consumption/gas/delivered", dsmrData.gas_delivered);
 
-    //     mqtt_send_metric("meter-stats/actual_tarif_group",
-    //     tariffIndicatorElectricity[3]);
-    send_metric("meter-stats/actual_tarif_group",
-                tariffIndicatorElectricity[3]);
-    mqtt_send_metric("meter-stats/power_failure_count", numberPowerFailuresAny);
-    mqtt_send_metric("meter-stats/long_power_failure_count",
-                     numberLongPowerFailuresAny);
-    mqtt_send_metric("meter-stats/short_power_drops", numberVoltageSagsL1);
-    mqtt_send_metric("meter-stats/short_power_peaks", numberVoltageSwellsL1);
+    send_metric("meter-stats/actual_tarif_group", dsmrData.electricity_tariff);
+    send_metric("meter-stats/power_failure_count", dsmrData.electricity_failures);
+    send_metric("meter-stats/long_power_failure_count", dsmrData.electricity_long_failures);
+    send_metric("meter-stats/short_power_drops", dsmrData.electricity_sags_l1);
+    send_metric("meter-stats/short_power_peaks", dsmrData.electricity_swells_l1);
 
     send_metric("day-consumption/electricity1",
-                (atof(electricityUsedTariff1) - atof(log_data.dayE1)));
+                (dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1)));
     send_metric("day-consumption/electricity2",
-                (atof(electricityUsedTariff2) - atof(log_data.dayE2)));
+                (dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2)));
     send_metric("day-consumption/electricity1_returned",
-                (atof(electricityReturnedTariff1) - atof(log_data.dayR1)));
+                (dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1)));
     send_metric("day-consumption/electricity2_returned",
-                (atof(electricityReturnedTariff2) - atof(log_data.dayR2)));
+                (dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2)));
 
     send_metric("day-consumption/electricity_merged",
-                ((atof(electricityUsedTariff1) - atof(log_data.dayE1)) +
-                 (atof(electricityUsedTariff2) - atof(log_data.dayE2))));
+                ((dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1)) +
+                 (dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2))));
     send_metric("day-consumption/electricity_returned_merged",
-                ((atof(electricityReturnedTariff1) - atof(log_data.dayR1)) +
-                 (atof(electricityReturnedTariff2) - atof(log_data.dayR2))));
+                ((dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1)) +
+                 (dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2))));
     send_metric("day-consumption/gas",
-                (atof(gasReceived5min) - atof(log_data.dayG)));
+                (dsmrData.gas_delivered.toFloat() - atof(log_data.dayG)));
 
     send_metric("current-month/electricity1",
-                (atof(electricityUsedTariff1) - atof(log_data.monthE1)));
+                (dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1)));
     send_metric("current-month/electricity2",
-                (atof(electricityUsedTariff2) - atof(log_data.monthE2)));
+                (dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2)));
     send_metric("current-month/electricity1_returned",
-                (atof(electricityReturnedTariff1) - atof(log_data.monthR1)));
+                (dsmrData.energy_returned_tariff1.val() - atof(log_data.monthR1)));
     send_metric("current-month/electricity2_returned",
-                (atof(electricityReturnedTariff2) - atof(log_data.monthR2)));
+                (dsmrData.energy_returned_tariff2.val() - atof(log_data.monthR2)));
 
     send_metric("current-month/electricity_merged",
-                ((atof(electricityUsedTariff1) - atof(log_data.monthE1)) +
-                 (atof(electricityUsedTariff2) - atof(log_data.monthE2))));
+                ((dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1)) +
+                 (dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2))));
     send_metric("current-month/electricity_returned_merged",
-                ((atof(electricityReturnedTariff1) - atof(log_data.monthR1)) +
-                 (atof(electricityReturnedTariff2) - atof(log_data.monthR2))));
+                ((dsmrData.energy_returned_tariff1.val() - atof(log_data.monthR1)) +
+                 (dsmrData.energy_returned_tariff2.val() - atof(log_data.monthR2))));
     send_metric("current-month/gas",
-                (atof(gasReceived5min) - atof(log_data.monthG)));
+                (dsmrData.gas_delivered.toFloat() - atof(log_data.monthG)));
   } else {
-    mqtt_send_metric("equipmentID", equipmentId);
+    send_metric("equipmentID", dsmrData.equipment_id);
 
-    mqtt_send_metric("consumption_low_tarif", electricityUsedTariff1);
-    mqtt_send_metric("consumption_high_tarif", electricityUsedTariff2);
-    mqtt_send_metric("returndelivery_low_tarif", electricityReturnedTariff1);
-    mqtt_send_metric("returndelivery_high_tarif", electricityReturnedTariff2);
-    mqtt_send_metric("actual_consumption", actualElectricityPowerDeli);
-    mqtt_send_metric("actual_returndelivery", actualElectricityPowerRet);
+    send_metric("consumption_low_tarif", dsmrData.energy_delivered_tariff1);
+    send_metric("consumption_high_tarif", dsmrData.energy_delivered_tariff2);
+    send_metric("returndelivery_low_tarif", dsmrData.energy_returned_tariff1);
+    send_metric("returndelivery_high_tarif", dsmrData.energy_returned_tariff2);
+    send_metric("actual_consumption", dsmrData.power_delivered);
+    send_metric("actual_returndelivery", dsmrData.power_returned);
 
-    mqtt_send_metric("l1_instant_power_usage", activePowerL1P);
-    mqtt_send_metric("l2_instant_power_usage", activePowerL2P);
-    mqtt_send_metric("l3_instant_power_usage", activePowerL3P);
-    mqtt_send_metric("l1_instant_power_current", instantaneousCurrentL1);
-    mqtt_send_metric("l2_instant_power_current", instantaneousCurrentL2);
-    mqtt_send_metric("l3_instant_power_current", instantaneousCurrentL3);
-    mqtt_send_metric("l1_voltage", instantaneousVoltageL1);
-    mqtt_send_metric("l2_voltage", instantaneousVoltageL2);
-    mqtt_send_metric("l3_voltage", instantaneousVoltageL3);
-    mqtt_send_metric("l1_instant_power_return", activePowerL1NP);
-    mqtt_send_metric("l2_instant_power_return", activePowerL2NP);
-    mqtt_send_metric("l3_instant_power_return", activePowerL3NP);
+    send_metric("l1_instant_power_usage", dsmrData.power_delivered_l1);
+    send_metric("l2_instant_power_usage", dsmrData.power_delivered_l2);
+    send_metric("l3_instant_power_usage", dsmrData.power_delivered_l3);
+    send_metric("l1_instant_power_current", dsmrData.current_l1);
+    send_metric("l2_instant_power_current", dsmrData.current_l2);
+    send_metric("l3_instant_power_current", dsmrData.current_l3);
+    send_metric("l1_voltage", dsmrData.voltage_l1);
+    send_metric("l2_voltage", dsmrData.voltage_l2);
+    send_metric("l3_voltage", dsmrData.voltage_l3);
+    send_metric("l1_instant_power_return", dsmrData.power_returned_l1);
+    send_metric("l2_instant_power_return", dsmrData.power_returned_l2);
+    send_metric("l3_instant_power_return", dsmrData.power_returned_l3);
 
-    mqtt_send_metric("gas_meter_m3", gasReceived5min);
+    send_metric("gas_meter_m3", dsmrData.gas_delivered);
 
-    send_metric("actual_tarif_group", tariffIndicatorElectricity[3]);
-    mqtt_send_metric("short_power_outages", numberPowerFailuresAny);
-    mqtt_send_metric("long_power_outages", numberLongPowerFailuresAny);
-    mqtt_send_metric("short_power_drops", numberVoltageSagsL1);
-    mqtt_send_metric("short_power_peaks", numberVoltageSwellsL1);
+    send_metric("actual_tarif_group", dsmrData.electricity_tariff);
+    send_metric("short_power_outages", dsmrData.electricity_failures);
+    send_metric("long_power_outages", dsmrData.electricity_long_failures);
+    send_metric("short_power_drops", dsmrData.electricity_sags_l1);
+    send_metric("short_power_peaks", dsmrData.electricity_swells_l1);
     LastReportinMillis = millis();
     LastMReport = timestampkaal();
     MqttDelivered = true;
     return;
   }
 #endif
-  // #ifdef GERMAN
-  //       mqtt_send_metric("equipmentID", equipmentId);
-
-  //       mqtt_send_metric("consumption_low_tarif", electricityUsedTariff1);
-  //       mqtt_send_metric("consumption_high_tarif", electricityUsedTariff2);
-  //       mqtt_send_metric("returndelivery_low_tarif",
-  //       electricityReturnedTariff1);
-  //       mqtt_send_metric("returndelivery_high_tarif",
-  //       electricityReturnedTariff2); mqtt_send_metric("actual_consumption",
-  //       actualElectricityPowerDeli);
-  //       mqtt_send_metric("actual_returndelivery", actualElectricityPowerRet);
-
-  //       mqtt_send_metric("l1_instant_power_usage", activePowerL1P);
-  //       mqtt_send_metric("l2_instant_power_usage", activePowerL2P);
-  //       mqtt_send_metric("l3_instant_power_usage", activePowerL3P);
-  //       mqtt_send_metric("l1_instant_power_current", instantaneousCurrentL1);
-  //       mqtt_send_metric("l2_instant_power_current", instantaneousCurrentL2);
-  //       mqtt_send_metric("l3_instant_power_current", instantaneousCurrentL3);
-  //       mqtt_send_metric("l1_voltage", instantaneousVoltageL1);
-  //       mqtt_send_metric("l2_voltage", instantaneousVoltageL2);
-  //       mqtt_send_metric("l3_voltage", instantaneousVoltageL3);
-
-  //       mqtt_send_metric("gas_meter_m3", gasReceived5min);
-
-  //       mqtt_send_metric("actual_tarif_group", tariffIndicatorElectricity);
-  //       mqtt_send_metric("short_power_outages", numberPowerFailuresAny);
-  //       mqtt_send_metric("long_power_outages", numberLongPowerFailuresAny);
-  //       mqtt_send_metric("short_power_drops", numberVoltageSagsL1);
-  //       mqtt_send_metric("short_power_peaks", numberVoltageSwellsL1);
-  //       LastReportinMillis = millis();
-  // #endif
-  // #ifdef SWEDISH
-  // /*
-  // 1-0:1.8.0 Mätarställning Aktiv Energi Uttag.
-  // 1-0:2.8.0 Mätarställning Aktiv Energi Inmatning
-  // 1-0:3.8.0 Mätarställning Reaktiv Energi Uttag
-  // 1-0:4.8.0 Mätarställning Reaktiv Energi Inmatning
-
-  // 1-0:1.7.0 Aktiv Effekt Uttag  Momentan trefaseffekt
-  // 1-0:2.7.0 Aktiv Effekt Inmatning  Momentan trefaseffekt
-  // 1-0:3.7.0 Reaktiv Effekt Uttag  Momentan trefaseffekt
-  // 1-0:4.7.0 Reaktiv Effekt Inmatning  Momentan trefaseffekt
-  // 1-0:21.7.0  L1 Aktiv Effekt Uttag Momentan effekt
-  // 1-0:22.7.0  L1 Aktiv Effekt Inmatning Momentan effekt
-  // 1-0:41.7.0  L2 Aktiv Effekt Uttag Momentan effekt
-  // 1-0:42.7.0  L2 Aktiv Effekt Inmatning Momentan effekt
-  // 1-0:61.7.0  L3 Aktiv Effekt Uttag Momentan effekt
-  // 1-0:62.7.0  L3 Aktiv Effekt Inmatning Momentan effekt
-  // 1-0:23.7.0  L1 Reaktiv Effekt Uttag Momentan effekt
-  // 1-0:24.7.0  L1 Reaktiv Effekt Inmatning Momentan effekt
-  // 1-0:43.7.0  L2 Reaktiv Effekt Uttag Momentan effekt
-  // 1-0:44.7.0  L2 Reaktiv Effekt Inmatning Momentan effekt
-  // 1-0:63.7.0  L3 Reaktiv Effekt Uttag Momentan effekt
-  // 1-0:64.7.0  L3 Reaktiv Effekt Inmatning Momentan effekt
-  // 1-0:32.7.0  L1 Fasspänning  Momentant RMS-värde
-  // 1-0:52.7.0  L2 Fasspänning  Momentant RMS-värde
-  // 1-0:72.7.0  L3 Fasspänning  Momentant RMS-värde
-  // 1-0:31.7.0  L1 Fasström Momentant RMS-värde
-  // 1-0:51.7.0  L2 Fasström Momentant RMS-värde
-  // 1-0:71.7.0  L3 Fasström Momentant RMS-värde
-  // */
-  // /*
-  //  * https://github.com/forsberg/esphome-p1reader
-  //  */
-  //       mqtt_send_metric("cumulativeActiveImport", cumulativeActiveImport);
-  //       // 1.8.0 mqtt_send_metric("cumulativeActiveExport",
-  //       cumulativeActiveExport);       // 2.8.0
-  //       mqtt_send_metric("cumulativeReactiveImport",
-  //       cumulativeReactiveImport);   // 3.8.0
-  //       mqtt_send_metric("cumulativeReactiveExport",
-  //       cumulativeReactiveExport);   // 4.8.0
-
-  //       mqtt_send_metric("momentaryActiveImport", momentaryActiveImport);
-  //       // 1.7.0 mqtt_send_metric("momentaryActiveExport",
-  //       momentaryActiveExport);         // 2.7.0
-  //       mqtt_send_metric("momentaryReactiveImport", momentaryReactiveImport);
-  //       // 3.7.0 mqtt_send_metric("momentaryReactiveExport",
-  //       momentaryReactiveExport);     // 4.7.0
-
-  //       mqtt_send_metric("momentaryActiveImportL1", activePowerL1P);
-  //       // 21.7.0 mqtt_send_metric("momentaryActiveExportL1",
-  //       reactivePowerL1NP);           // 22.7.0
-
-  //       mqtt_send_metric("momentaryActiveImportL2", activePowerL2P);
-  //       // 41.7.0 mqtt_send_metric("momentaryActiveExportL2",
-  //       reactivePowerL2NP);           // 42.7.0
-
-  //       mqtt_send_metric("momentaryActiveImportL3", activePowerL3P);
-  //       // 61.7.0 mqtt_send_metric("momentaryActiveExportL3",
-  //       reactivePowerL3NP);           // 62.7.0
-
-  //       mqtt_send_metric("momentaryReactiveImportL1",
-  //       momentaryReactiveImportL1);   // 23.7.0
-  //       mqtt_send_metric("momentaryReactiveImportL1",
-  //       momentaryReactiveExportL1);   // 24.7.0
-
-  //       mqtt_send_metric("momentaryReactiveImportL2",
-  //       momentaryReactiveImportL2);   // 43.7.0
-  //       mqtt_send_metric("momentaryReactiveExportL2",
-  //       momentaryReactiveExportL2);   // 44.7.0
-
-  //       mqtt_send_metric("momentaryReactiveImportL3",
-  //       momentaryReactiveImportL3);   // 63.7.0
-  //       mqtt_send_metric("momentaryReactiveExportL1",
-  //       momentaryReactiveExportL3);   // 64.7.0
-
-  //       mqtt_send_metric("voltageL1", instantaneousVoltageL1);  // 32.7.0
-  //       mqtt_send_metric("voltageL2", instantaneousVoltageL2);  // 52.7.0
-  //       mqtt_send_metric("voltageL3", instantaneousVoltageL3);  // 72.7.0
-
-  //       mqtt_send_metric("currentL1", instantaneousCurrentL1);  // 31.7.0
-  //       mqtt_send_metric("currentL2", instantaneousCurrentL2);  // 51.7.0
-  //       mqtt_send_metric("currentL3", instantaneousCurrentL3);  // 71.7.0
-  // //      mqtt_send_metric("P1module_voltage", outstr);
-  // #endif
   LastMReport = timestampkaal();
   MqttDelivered = true;
   LastReportinMillis = millis();

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -160,192 +160,174 @@ String readFirstParenthesisVal(int start, int end){
       case 0:
         break;
       case 13028: // device type
-        readFirstParenthesisVal(i, len).toCharArray(P1version, sizeof(P1version));
-                if (P1version[0] =='4') P1prot = 4; else P1prot = 5;
+        dsmrData.p1_version = readFirstParenthesisVal(i, len);
         break;
       case 100:
-        readFirstParenthesisVal(i, len).toCharArray(P1timestamp, sizeof(P1timestamp));
+        dsmrData.timestamp = readFirstParenthesisVal(i, len);
         Log.verbose("timestamp: ");
-        Log.verboseln(P1timestamp);
+        Log.verboseln(dsmrData.timestamp.c_str());
         break;
-
       case 96140:
-        readFirstParenthesisVal(i, len).toCharArray(tariffIndicatorElectricity, sizeof(tariffIndicatorElectricity));
+        dsmrData.electricity_tariff = readFirstParenthesisVal(i, len);
         Log.verbose("tarief: ");
-        Log.verboseln(tariffIndicatorElectricity);
+        Log.verboseln(dsmrData.electricity_tariff.c_str());
         break;
       case 9611:
-        readFirstParenthesisVal(i, len).toCharArray(equipmentId, sizeof(equipmentId));
+        dsmrData.equipment_id = readFirstParenthesisVal(i, len);
         Log.verbose("meter id: ");
-        Log.verboseln(equipmentId);
+        Log.verboseln(dsmrData.equipment_id.c_str());
         break;
       case 19610:
-        readFirstParenthesisVal(i, len).toCharArray(equipmentId2, sizeof(equipmentId2));
+        dsmrData.gas_equipment_id = readFirstParenthesisVal(i, len);
         Log.verbose("meter id2: ");
-        Log.verboseln(equipmentId2);
+        Log.verboseln(dsmrData.gas_equipment_id.c_str());
         break;
       case 9810:
         Log.verboseln("storingen");
         break;
       case 10170: // 1-0:1.7.0 – actualElectricityPowerDelivered
-        readUntilStar(i, len).toCharArray(actualElectricityPowerDeli, sizeof(actualElectricityPowerDeli));
+        dsmrData.power_delivered = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:1.7.x > ");
-        Log.verboseln(actualElectricityPowerDeli);
+        Log.verboseln("%F", dsmrData.power_delivered.val());
         break;
       case 10270: // 1-0:1.7.0 – actualElectricityPowerReturned
-        readUntilStar(i, len).toCharArray(actualElectricityPowerRet, sizeof(actualElectricityPowerRet));
+        dsmrData.power_returned = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:2.7.0 > ");
-        Log.verboseln(actualElectricityPowerRet);
+        Log.verboseln("%F", dsmrData.power_returned.val());
         break;
-
       case 10180: // 1-0:1.8.0 – actualElectricityPowerDelivered
         Log.verbose("non existent ");
-        readUntilStar(i, len).toCharArray(actualElectricityPowerDeli, sizeof(actualElectricityPowerDeli));
+        dsmrData.power_delivered = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:1.7.x > ");
-        Log.verboseln(actualElectricityPowerDeli);
+        Log.verboseln("%F", dsmrData.power_delivered.val());
         break;
       case 10181:  // 1-0:1.8.1(000992.992*kWh) Elektra verbruik laag tarief
-        readUntilStar(i, len).toCharArray(electricityUsedTariff1, sizeof(electricityUsedTariff1));
+        dsmrData.energy_delivered_tariff1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:1.8.1 > ");
-        Log.verboseln(electricityUsedTariff1);
+        Log.verboseln("%F", dsmrData.energy_delivered_tariff1.val());
         break;
       case 10182: // 1-0:1.8.2(000560.157*kWh) = Elektra verbruik hoog tarief
-        readUntilStar(i, len).toCharArray(electricityUsedTariff2, sizeof(electricityUsedTariff2));
+        dsmrData.energy_delivered_tariff2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:1.8.2 > ");
-        Log.verboseln(electricityUsedTariff2);
+        Log.verboseln("%F", dsmrData.energy_delivered_tariff2.val());
         break;
       case 10281: // 1-0:2.8.1(000348.890*kWh) Elektra opbrengst laag tarief
-        readUntilStar(i, len).toCharArray(electricityReturnedTariff1, sizeof(electricityReturnedTariff1));
+        dsmrData.energy_returned_tariff1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:2.8.1 > ");
-        Log.verboseln(electricityReturnedTariff1);
+        Log.verboseln("%F", dsmrData.energy_returned_tariff1.val());
         break;
       case 10282: // 1-0:2.8.2(000859.885*kWh) Elektra opbrengst hoog tarief
-        readUntilStar(i, len).toCharArray(electricityReturnedTariff2, sizeof(electricityReturnedTariff2));
+        dsmrData.energy_returned_tariff2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:2.8.2 > ");
-        Log.verboseln(electricityReturnedTariff2);
+        Log.verboseln("%F", dsmrData.energy_returned_tariff2.val());
         break;
-
-       case 103170:  // 1-0:31.7.0(002*A) Instantane stroom Elektriciteit L1
-        readUntilStar(i, len).toCharArray(instantaneousCurrentL1, sizeof(instantaneousCurrentL1));
+      case 103170:  // 1-0:31.7.0(002*A) Instantane stroom Elektriciteit L1
+        dsmrData.current_l1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:31.7.0 > ");
-        Log.verboseln(instantaneousCurrentL1);
+        Log.verboseln("%F", dsmrData.current_l1.val());
         break;
-       case 105170:  // 1-0:51.7.0(002*A) Instantane stroom Elektriciteit L2
-        readUntilStar(i, len).toCharArray(instantaneousCurrentL2, sizeof(instantaneousCurrentL2));
+      case 105170:  // 1-0:51.7.0(002*A) Instantane stroom Elektriciteit L2
+        dsmrData.current_l2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:51.7.0 > ");
-        Log.verboseln(instantaneousCurrentL2);
+        Log.verboseln("%F", dsmrData.current_l2.val());
         break;
-       case 107170:  // 1-0:71.7.0(002*A) Instantane stroom Elektriciteit L3
-        readUntilStar(i, len).toCharArray(instantaneousCurrentL3, sizeof(instantaneousCurrentL3));
+      case 107170:  // 1-0:71.7.0(002*A) Instantane stroom Elektriciteit L3
+        dsmrData.current_l3 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:71.7.0 > ");
-        Log.verboseln(instantaneousCurrentL3);
+        Log.verboseln("%F", dsmrData.current_l3.val());
         break;
-
-
-       case 103270: // 1-0:32.7.0(232.0*V) Voltage L1
-        readUntilStar(i, len).toCharArray(instantaneousVoltageL1, sizeof(instantaneousVoltageL1));
+      case 103270: // 1-0:32.7.0(232.0*V) Voltage L1
+        dsmrData.voltage_l1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:32.7.0 > ");
-        Log.verboseln(instantaneousVoltageL1);
+        Log.verboseln("%F", dsmrData.voltage_l1.val());
         break;
-       case 105270: // 1-0:52.7.0(232.0*V) Voltage L2
-        readUntilStar(i, len).toCharArray(instantaneousVoltageL2, sizeof(instantaneousVoltageL2));
+      case 105270: // 1-0:52.7.0(232.0*V) Voltage L2
+        dsmrData.voltage_l2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:32.7.0 > ");
-        Log.verboseln(instantaneousVoltageL2);
+        Log.verboseln("%F", dsmrData.voltage_l2.val());
         break;
-       case 107270: // 1-0:72.7.0(232.0*V) Voltage L3
-        readUntilStar(i, len).toCharArray(instantaneousVoltageL3, sizeof(instantaneousVoltageL3));
+      case 107270: // 1-0:72.7.0(232.0*V) Voltage L3
+        dsmrData.voltage_l3 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:72.7.0 > ");
-        Log.verboseln(instantaneousVoltageL3);
+        Log.verboseln("%F", dsmrData.voltage_l3.val());
         break;
-
-
-       case 102170:  // 1-0:21.7.0(002*A) Instantane stroom Elektriciteit L1
-        readUntilStar(i, len).toCharArray(activePowerL1P, sizeof(activePowerL1P));
+      case 102170:  // 1-0:21.7.0(002*A) Instantane stroom Elektriciteit L1
+        dsmrData.power_delivered_l1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:21.7.0 > ");
-        Log.verboseln(activePowerL1P);
+        Log.verboseln("%F", dsmrData.power_delivered_l1.val());
         break;
-       case 104170:  // 1-0:41.7.0(002*A) Instantane stroom Elektriciteit L2
-        readUntilStar(i, len).toCharArray(activePowerL2P, sizeof(activePowerL2P));
+      case 104170:  // 1-0:41.7.0(002*A) Instantane stroom Elektriciteit L2
+        dsmrData.power_delivered_l2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:41.7.0 > ");
-        Log.verboseln(activePowerL2P);
+        Log.verboseln("%F", dsmrData.power_delivered_l2.val());
         break;
       case 106170:  // 1-0:61.7.0(002*A) Instantane stroom Elektriciteit L3
-        readUntilStar(i, len).toCharArray(activePowerL3P, sizeof(activePowerL3P));
+        dsmrData.power_delivered_l3 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:61.7.0 > ");
-        Log.verboseln(activePowerL3P);
+        Log.verboseln("%F", dsmrData.power_delivered_l3.val());
         break;
-
-       case 102270: // 1-0:22.7.0(232.0*V) Voltage L1
-        readUntilStar(i, len).toCharArray(activePowerL1NP, sizeof(activePowerL1NP));
+      case 102270: // 1-0:22.7.0(232.0*V) Voltage L1
+        dsmrData.power_returned_l1 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:22.7.0 > ");
-        Log.verboseln(activePowerL1NP);
+        Log.verboseln("%F", dsmrData.power_returned_l1.val());
         break;
-       case 104270: // 1-0:42.7.0(232.0*V) Voltage L2
-        readUntilStar(i, len).toCharArray(activePowerL2NP, sizeof(activePowerL2NP));
+      case 104270: // 1-0:42.7.0(232.0*V) Voltage L2
+        dsmrData.power_returned_l2 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:42.7.0 > ");
-        Log.verboseln(activePowerL2NP);
+        Log.verboseln("%F", dsmrData.power_returned_l2.val());
         break;
-       case 106270: // 1-0:62.7.0(232.0*V) Voltage L3
-        readUntilStar(i, len).toCharArray(activePowerL3NP, sizeof(activePowerL3NP));
+      case 106270: // 1-0:62.7.0(232.0*V) Voltage L3
+        dsmrData.power_returned_l3 = FixedValue(readUntilStar(i, len));
         Log.verbose("1-0:62.7.0 > ");
-        Log.verboseln(activePowerL3NP);
+        Log.verboseln("%F", dsmrData.power_returned_l3.val());
         break;
-
-
-       case 1032320: // Aantal korte spanningsdalingen Elektriciteit in fase 1
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL1, sizeof(numberVoltageSagsL1));
+      case 1032320: // Aantal korte spanningsdalingen Elektriciteit in fase 1
+        dsmrData.electricity_sags_l1 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:32.32.0 > ");
-        Log.verboseln(numberVoltageSagsL1);
+        Log.verboseln("%d", dsmrData.electricity_sags_l1);
         break;
-       case 1052320: // Aantal korte spanningsdalingen Elektriciteit in fase 2
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL2, sizeof(numberVoltageSagsL2));
+      case 1052320: // Aantal korte spanningsdalingen Elektriciteit in fase 2
+        dsmrData.electricity_sags_l2 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:52.32.0 > ");
-        Log.verboseln(numberVoltageSagsL2);
+        Log.verboseln("%d", dsmrData.electricity_sags_l2);
         break;
-       case 1072320: // Aantal korte spanningsdalingen Elektriciteit in fase 3
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSagsL3, sizeof(numberVoltageSagsL3));
+      case 1072320: // Aantal korte spanningsdalingen Elektriciteit in fase 3
+        dsmrData.electricity_sags_l3 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:72.32.0 > ");
-        Log.verboseln(numberVoltageSagsL3);
+        Log.verboseln("%d", dsmrData.electricity_sags_l3);
         break;
-
-       case 1032360: // 1-0:32.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 1
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL1, sizeof(numberVoltageSwellsL1));
+      case 1032360: // 1-0:32.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 1
+        dsmrData.electricity_swells_l1 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:32.36.0 > ");
-        Log.verboseln(numberVoltageSwellsL1);
+        Log.verboseln("%d", dsmrData.electricity_swells_l1);
         break;
-       case 1052360: // 1-0:52.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 2
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL2, sizeof(numberVoltageSwellsL2));
+      case 1052360: // 1-0:52.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 2
+        dsmrData.electricity_swells_l2 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:52.36.0 > ");
-        Log.verboseln(numberVoltageSwellsL2);
+        Log.verboseln("%d", dsmrData.electricity_swells_l2);
         break;
-       case 1072360: // 1-0:72.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 3
-        readFirstParenthesisVal(i, len).toCharArray(numberVoltageSwellsL3, sizeof(numberVoltageSwellsL3));
+      case 1072360: // 1-0:72.36.0(00000) Aantal korte spanningsstijgingen Elektriciteit in fase 3
+        dsmrData.electricity_swells_l3 = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("1-0:72.36.0 > ");
-        Log.verboseln(numberVoltageSwellsL3);
+        Log.verboseln("%d", dsmrData.electricity_swells_l3);
         break;
-
-       case 12421: // gas
-        readBetweenDoubleParenthesis(i, len).toCharArray(gasReceived5min, sizeof(gasReceived5min));
-        readBetweenDoubleParenthesis(i, len).toCharArray(gasDomoticz, sizeof(gasDomoticz));
+      case 12421: // gas
+        dsmrData.gas_delivered = readBetweenDoubleParenthesis(i, len);
         Log.verbose("gas: 0-1:24.2.1 > ");
-        Log.verboseln(gasReceived5min);
+        Log.verbose(dsmrData.gas_delivered.c_str());
         break;
       case 96721: // 0-0:96.7.21(00051)  Number of power failures in any phase
-        readFirstParenthesisVal(i, len).toCharArray(numberPowerFailuresAny, sizeof(numberPowerFailuresAny));
+        dsmrData.electricity_failures = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("0-0:96.7.21 > ");
-        Log.verboseln(numberPowerFailuresAny);
+        Log.verboseln("%d", dsmrData.electricity_failures);
         break;
       case 9679: // 0-0:96.7.9(00007) Number of long power failures in any phase
-        readFirstParenthesisVal(i, len).toCharArray(numberLongPowerFailuresAny, sizeof(numberLongPowerFailuresAny));
+        dsmrData.electricity_long_failures = readFirstParenthesisVal(i, len).toInt();
         Log.verbose("0-0:96.7.21 > ");
-        Log.verboseln(numberLongPowerFailuresAny);
+        Log.verboseln("%d", dsmrData.electricity_long_failures);
         break;
       case 1099970: //1-0:99.97.0(6) Power Failure Event Log (long power failures)
-        longPowerFailuresLog = "";
-        while (i < len) {
-          longPowerFailuresLog += (char)telegram[i];
-          i++;
-        }
+        dsmrData.electricity_failure_log = String(telegram[i], len);
         break;
       default:
         Log.verbose(" onbekende OBIS: ");

--- a/src/functions.h
+++ b/src/functions.h
@@ -81,17 +81,6 @@ int FindCharInArray(char array[], char c, int len) {
   return -1;
 }
 
-void settime() {
-  //(hr,min,sec,day,mnth,yr);
-  // YYMMDDhhmmssX
-  setTime(NUM(6, 10) + NUM(7, 1), NUM(8, 10) + NUM(9, 1),
-          NUM(10, 10) + NUM(11, 1), NUM(4, 10) + NUM(5, 1),
-          NUM(2, 10) + NUM(3, 1), NUM(0, 10) + NUM(1, 1));
-  Log.verbose("%d", timestamp());
-  LastReportinSecs = now();
-  timeIsSet = true;
-}
-
 String timestamp() {
   return (String) "time: " + hour() + ":" + minute() + ":" + second();
 }
@@ -406,76 +395,76 @@ String totalXY(const char *typeC, String period) {
   type += typeC[1];
   if (period == "day") {
     if (type == "E1")
-      return (String)(atof(electricityUsedTariff1) - atof(log_data.dayE1));
+      return (String)(dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1));
     if (type == "E2")
-      return (String)(atof(electricityUsedTariff2) - atof(log_data.dayE2));
+      return (String)(dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2));
     if (type == "R1")
-      return (String)(atof(electricityReturnedTariff1) - atof(log_data.dayR1));
+      return (String)(dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1));
     if (type == "R2")
-      return (String)(atof(electricityReturnedTariff2) - atof(log_data.dayR2));
+      return (String)(dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2));
     if (type == "TE") {
-      dtostrf((atof(electricityUsedTariff1) - atof(log_data.dayE1)) +
-                  (atof(electricityUsedTariff2) - atof(log_data.dayE2)),
+      dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1)) +
+                  (dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "TR") {
-      dtostrf((atof(electricityReturnedTariff1) - atof(log_data.dayR1)) +
-                  (atof(electricityReturnedTariff2) - atof(log_data.dayR2)),
+      dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1)) +
+                  (dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "G0")
-      return (String)(atof(gasReceived5min) - atof(log_data.dayG));
+      return (String)(dsmrData.gas_delivered.toFloat() - atof(log_data.dayG));
 
   } else if (period == "week") {
     if (type == "E1")
-      return (String)(atof(electricityUsedTariff1) - atof(log_data.weekE1));
+      return (String)(dsmrData.energy_delivered_tariff1.val() - atof(log_data.weekE1));
     if (type == "E2")
-      return (String)(atof(electricityUsedTariff2) - atof(log_data.weekE2));
+      return (String)(dsmrData.energy_delivered_tariff2.val() - atof(log_data.weekE2));
     if (type == "R1")
-      return (String)(atof(electricityReturnedTariff1) - atof(log_data.weekR1));
+      return (String)(dsmrData.energy_returned_tariff1.val() - atof(log_data.weekR1));
     if (type == "R2")
-      return (String)(atof(electricityReturnedTariff2) - atof(log_data.weekR2));
+      return (String)(dsmrData.energy_returned_tariff2.val() - atof(log_data.weekR2));
     if (type == "TE") {
-      dtostrf((atof(electricityUsedTariff1) - atof(log_data.weekE1)) +
-                  (atof(electricityUsedTariff2) - atof(log_data.weekE2)),
+      dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.weekE1)) +
+                  (dsmrData.energy_delivered_tariff2.val() - atof(log_data.weekE2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "TR") {
-      dtostrf((atof(electricityReturnedTariff1) - atof(log_data.weekR1)) +
-                  (atof(electricityReturnedTariff2) - atof(log_data.weekR2)),
+      dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.weekR1)) +
+                  (dsmrData.energy_returned_tariff2.val() - atof(log_data.weekR2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "G0")
-      return (String)(atof(gasReceived5min) - atof(log_data.weekG));
+      return (String)(dsmrData.gas_delivered.toFloat() - atof(log_data.weekG));
   } else if (period == "month") {
     if (type == "E1")
-      return (String)(atof(electricityUsedTariff1) - atof(log_data.monthE1));
+      return (String)(dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1));
     if (type == "E2")
-      return (String)(atof(electricityUsedTariff2) - atof(log_data.monthE2));
+      return (String)(dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2));
     if (type == "R1")
-      return (String)(atof(electricityReturnedTariff1) -
+      return (String)(dsmrData.energy_returned_tariff1.val() -
                       atof(log_data.monthR1));
     if (type == "R2")
-      return (String)(atof(electricityReturnedTariff2) -
+      return (String)(dsmrData.energy_returned_tariff2.val() -
                       atof(log_data.monthR2));
     if (type == "TE") {
-      dtostrf((atof(electricityUsedTariff1) - atof(log_data.monthE1)) +
-                  (atof(electricityUsedTariff2) - atof(log_data.monthE2)),
+      dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1)) +
+                  (dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "TR") {
-      dtostrf((atof(electricityReturnedTariff1) - atof(log_data.monthR1)) +
-                  (atof(electricityReturnedTariff2) - atof(log_data.monthR2)),
+      dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.monthR1)) +
+                  (dsmrData.energy_returned_tariff2.val() - atof(log_data.monthR2)),
               6, 2, value);
       return (String)value;
     }
     if (type == "G0")
-      return (String)(atof(gasReceived5min) - atof(log_data.monthG));
+      return (String)(dsmrData.gas_delivered.toFloat() - atof(log_data.monthG));
   } else if (period == "year") {
     return "Year not implemented yet";
   }

--- a/src/logging.h
+++ b/src/logging.h
@@ -51,29 +51,29 @@ void doInitLogVars() {
   char value[12];
   // init all vars on current (first) reading
   Log.verbose("Initialising log vars ... ");
-  strcpy(log_data.hourE1, electricityUsedTariff1);
-  strcpy(log_data.dayE1, electricityUsedTariff1);
-  strcpy(log_data.weekE1, electricityUsedTariff1);
-  strcpy(log_data.monthE1, electricityUsedTariff1);
-  strcpy(log_data.yearE1, electricityUsedTariff1);
+  strcpy(log_data.hourE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.dayE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.weekE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.monthE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.yearE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
 
-  strcpy(log_data.hourE2, electricityUsedTariff2);
-  strcpy(log_data.dayE2, electricityUsedTariff2);
-  strcpy(log_data.weekE2, electricityUsedTariff2);
-  strcpy(log_data.monthE2, electricityUsedTariff2);
-  strcpy(log_data.yearE2, electricityUsedTariff2);
+  strcpy(log_data.hourE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.dayE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.weekE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.monthE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.yearE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
 
-  strcpy(log_data.hourR1, electricityReturnedTariff1);
-  strcpy(log_data.dayR1, electricityReturnedTariff1);
-  strcpy(log_data.weekR1, electricityReturnedTariff1);
-  strcpy(log_data.monthR1, electricityReturnedTariff1);
-  strcpy(log_data.yearR1, electricityReturnedTariff1);
+  strcpy(log_data.hourR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.dayR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.weekR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.monthR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.yearR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
 
-  strcpy(log_data.hourR2, electricityReturnedTariff2);
-  strcpy(log_data.dayR2, electricityReturnedTariff2);
-  strcpy(log_data.weekR2, electricityReturnedTariff2);
-  strcpy(log_data.monthR2, electricityReturnedTariff2);
-  strcpy(log_data.yearR2, electricityReturnedTariff2);
+  strcpy(log_data.hourR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
+  strcpy(log_data.dayR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
+  strcpy(log_data.weekR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
+  strcpy(log_data.monthR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
+  strcpy(log_data.yearR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 
   dtostrf((atof(log_data.hourE1) + atof(log_data.hourE2)), 6, 2, value);
   strcpy(log_data.hourTE, value);
@@ -96,11 +96,11 @@ void doInitLogVars() {
 void doInitLogVarsGas() {
   Log.verboseln("Initialising log GAS vars ... ");
 
-  strcpy(log_data.hourG, gasReceived5min);
-  strcpy(log_data.dayG, gasReceived5min);
-  strcpy(log_data.weekG, gasReceived5min);
-  strcpy(log_data.monthG, gasReceived5min);
-  strcpy(log_data.yearG, gasReceived5min);
+  strcpy(log_data.hourG, dsmrData.gas_delivered.c_str());
+  strcpy(log_data.dayG, dsmrData.gas_delivered.c_str());
+  strcpy(log_data.weekG, dsmrData.gas_delivered.c_str());
+  strcpy(log_data.monthG, dsmrData.gas_delivered.c_str());
+  strcpy(log_data.yearG, dsmrData.gas_delivered.c_str());
   needToInitLogVarsGas = false;
   Log.verboseln("done.");
 }
@@ -110,11 +110,11 @@ void doMinutelyLog() {
   FST.begin();
   char buffer[60];
   char value[13];
-  dtostrf((atof(gasReceived5min) - atof(minG)), 6, 2, value);
+  dtostrf((dsmrData.gas_delivered.toFloat() - atof(minG)), 6, 2, value);
   sprintf(buffer, "['%s:%s:%s',%s],\n", (char*)hour(), (char*)minute(),
           (char*)second(), value);
   appendFile("/MinG.log", buffer);
-  strcpy(minG, gasReceived5min);
+  strcpy(minG, dsmrData.gas_delivered.c_str());
   FST.end();
   MountFS();
 }
@@ -132,32 +132,32 @@ void doHourlyLog() {
   char buffer[60];
   char value[13];
 
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.hourE1)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.hourE1)), 6, 2, value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
   appendFile("/HourE1.log", buffer);
-  strcpy(log_data.hourE1, electricityUsedTariff1);
+  strcpy(log_data.hourE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
 
-  dtostrf((atof(electricityUsedTariff2) - atof(log_data.hourE2)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff2.val() - atof(log_data.hourE2)), 6, 2, value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
   appendFile("/HourE2.log", buffer);
-  strcpy(log_data.hourE2, electricityUsedTariff2);
+  strcpy(log_data.hourE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
 
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.hourR1)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.hourR1)), 6, 2,
           value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
   appendFile("/HourR1.log", buffer);
-  strcpy(log_data.hourR1, electricityReturnedTariff1);
+  strcpy(log_data.hourR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
 
-  dtostrf((atof(electricityReturnedTariff2) - atof(log_data.hourR2)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff2.val() - atof(log_data.hourR2)), 6, 2,
           value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
   appendFile("/HourR2.log", buffer);
-  strcpy(log_data.hourR2, electricityReturnedTariff2);
+  strcpy(log_data.hourR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 
-  dtostrf((atof(gasReceived5min) - atof(log_data.hourG)), 6, 2, value);
+  dtostrf((dsmrData.gas_delivered.toFloat() - atof(log_data.hourG)), 6, 2, value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
   appendFile("/HourG.log", buffer);
-  strcpy(log_data.hourG, gasReceived5min);
+  strcpy(log_data.hourG, dsmrData.gas_delivered.c_str());
 
   dtostrf((atof(log_data.hourE1) + atof(log_data.hourE2)), 6, 2, value);
   sprintf(buffer, "['%d',%s],\n", hour(), value);
@@ -212,42 +212,41 @@ void doDailyLog() {
   if ((day()) < 10)
     str += "0";
   str += day();
-
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.dayE1)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1)), 6, 2, value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
   //  appendFile("DayE1.log", buffer);
   appendFile("/WeekE1.log", buffer);
   appendFile("/MonthE1.log", buffer);
   appendFile("/YearE1.log", buffer);
-  strcpy(log_data.dayE1, electricityUsedTariff1);
+  strcpy(log_data.dayE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
 
-  dtostrf((atof(electricityUsedTariff2) - atof(log_data.dayE2)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2)), 6, 2, value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
   //  appendFile("DayE2.log", buffer);
   appendFile("/WeekE2.log", buffer);
   appendFile("/MonthE2.log", buffer);
   appendFile("/YearE2.log", buffer);
-  strcpy(log_data.dayE2, electricityUsedTariff2);
+  strcpy(log_data.dayE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
 
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.dayR1)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1)), 6, 2,
           value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
   //  appendFile("/DayR1.log", buffer);
   appendFile("/WeekR1.log", buffer);
   appendFile("/MonthR1.log", buffer);
   appendFile("/YearR1.log", buffer);
-  strcpy(log_data.dayR1, electricityReturnedTariff1);
+  strcpy(log_data.dayR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
 
-  dtostrf((atof(electricityReturnedTariff2) - atof(log_data.dayR2)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2)), 6, 2,
           value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
   //  appendFile("DayR2.log", buffer);
   appendFile("/WeekR2.log", buffer);
   appendFile("/MonthR2.log", buffer);
   appendFile("/YearR2.log", buffer);
-  strcpy(log_data.dayR2, electricityReturnedTariff2);
+  strcpy(log_data.dayR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 
-  dtostrf((atof(gasReceived5min) - atof(log_data.dayG)), 6, 2, value);
+  dtostrf((dsmrData.gas_delivered.toFloat() - atof(log_data.dayG)), 6, 2, value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
   //  appendFile("DayG.log", buffer);
   appendFile("/WeekG.log", buffer);
@@ -258,7 +257,7 @@ void doDailyLog() {
   // sprintf(buffer, "(%s , %s , %s), %s],\n", (char*)year(), (char*)0, (char*)day(), value); //
   // Google graph format uses month 0 for Jan!!
   appendFile("/YearGc.log", buffer);
-  strcpy(log_data.dayG, gasReceived5min);
+  strcpy(log_data.dayG, dsmrData.gas_delivered.c_str());
 
   dtostrf((atof(log_data.dayE1) + atof(log_data.dayE2)), 6, 2, value);
   sprintf(buffer, "['%s',%s],\n", string2char(str), value);
@@ -309,38 +308,38 @@ void doWeeklyLog() {
 
   deleteFile("/WeekE1-1.log");
   renameFile("/WeekE1.log", "/WeekE1-1.log");
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.weekE1)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.weekE1)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksE1.log", buffer);
-  strcpy(log_data.weekE1, electricityUsedTariff1);
+  strcpy(log_data.weekE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
 
   deleteFile("/WeekE2-1.log");
   renameFile("/WeekE2.log", "/WeekE2-1.log");
-  dtostrf((atof(electricityUsedTariff2) - atof(log_data.weekE2)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff2.val() - atof(log_data.weekE2)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksE2.log", buffer);
-  strcpy(log_data.weekE2, electricityUsedTariff2);
+  strcpy(log_data.weekE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
 
   deleteFile("/WeekR1-1.log");
   renameFile("/WeekR1.log", "/WeekR1-1.log");
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.weekR1)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.weekR1)), 6, 2,
           value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksR1.log", buffer);
-  strcpy(log_data.weekR1, electricityReturnedTariff1);
+  strcpy(log_data.weekR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
 
   deleteFile("/WeekR2-1.log");
   renameFile("/WeekR2.log", "/WeekR2-1.log");
-  dtostrf((atof(electricityReturnedTariff2) - atof(log_data.weekR2)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff2.val() - atof(log_data.weekR2)), 6, 2,
           value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksR2.log", buffer);
-  strcpy(log_data.weekR2, electricityReturnedTariff2);
+  strcpy(log_data.weekR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 
   deleteFile("/WeekTE-1.log");
   renameFile("/WeekTE.log", "/WeekTE-1.log");
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.weekE1)) +
-              (atof(electricityUsedTariff2) - atof(log_data.weekE2)),
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.weekE1)) +
+              (dsmrData.energy_delivered_tariff2.val() - atof(log_data.weekE2)),
           6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksTE.log", buffer);
@@ -348,8 +347,8 @@ void doWeeklyLog() {
 
   deleteFile("/WeekTR-1.log");
   renameFile("/WeekTR.log", "/WeekTR-1.log");
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.weekR1)) +
-              (atof(electricityReturnedTariff2) - atof(log_data.weekR2)),
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.weekR1)) +
+              (dsmrData.energy_returned_tariff2.val() - atof(log_data.weekR2)),
           6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksTR.log", buffer);
@@ -357,7 +356,7 @@ void doWeeklyLog() {
 
   deleteFile("/WeekG-1.log");
   renameFile("/WeekG.log", "/WeekG-1.log");
-  dtostrf((atof(gasReceived5min) - atof(log_data.dayG)), 6, 2, value);
+  dtostrf((dsmrData.gas_delivered.toFloat() - atof(log_data.dayG)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/WeeksG.log", buffer);
   strcpy(log_data.weekG, value);
@@ -387,38 +386,38 @@ void doMonthlyLog() {
 
   deleteFile("/MonthE1-1.log");
   renameFile("/MonthE1.log", "/MonthE1-1.log");
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.monthE1)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsE1.log", buffer);
-  strcpy(log_data.monthE1, electricityUsedTariff1);
+  strcpy(log_data.monthE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
 
   deleteFile("/MonthE2-1.log");
   renameFile("/MonthE2.log", "/MonthE2-1.log");
-  dtostrf((atof(electricityUsedTariff2) - atof(log_data.monthE2)), 6, 2, value);
+  dtostrf((dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsE2.log", buffer);
-  strcpy(log_data.monthE2, electricityUsedTariff2);
+  strcpy(log_data.monthE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
 
   deleteFile("/MonthR1-1.log");
   renameFile("/MonthR1.log", "/MonthR1-1.log");
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.monthR1)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.monthR1)), 6, 2,
           value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsR1.log", buffer);
-  strcpy(log_data.monthR1, electricityReturnedTariff1);
+  strcpy(log_data.monthR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
 
   deleteFile("/MonthR2-1.log");
   renameFile("/MonthR2.log", "/MonthR2-1.log");
-  dtostrf((atof(electricityReturnedTariff2) - atof(log_data.monthR2)), 6, 2,
+  dtostrf((dsmrData.energy_returned_tariff2.val() - atof(log_data.monthR2)), 6, 2,
           value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsR2.log", buffer);
-  strcpy(log_data.monthR2, electricityReturnedTariff2);
+  strcpy(log_data.monthR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 
   deleteFile("/MonthTE-1.log");
   renameFile("/MonthTE.log", "/MonthTE-1.log");
-  dtostrf((atof(electricityUsedTariff1) - atof(log_data.monthE1)) +
-              (atof(electricityUsedTariff2) - atof(log_data.monthE2)),
+  dtostrf((dsmrData.energy_delivered_tariff1.val() - atof(log_data.monthE1)) +
+              (dsmrData.energy_delivered_tariff2.val() - atof(log_data.monthE2)),
           6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsTE.log", buffer);
@@ -426,8 +425,8 @@ void doMonthlyLog() {
 
   deleteFile("/MonthTR-1.log");
   renameFile("/MonthTR.log", "/MonthTR-1.log");
-  dtostrf((atof(electricityReturnedTariff1) - atof(log_data.monthR1)) +
-              (atof(electricityReturnedTariff2) - atof(log_data.monthR2)),
+  dtostrf((dsmrData.energy_returned_tariff1.val() - atof(log_data.monthR1)) +
+              (dsmrData.energy_returned_tariff2.val() - atof(log_data.monthR2)),
           6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsTR.log", buffer);
@@ -435,7 +434,7 @@ void doMonthlyLog() {
 
   deleteFile("/MonthG-1.log");
   renameFile("/MonthG.log", "/MonthG-1.log");
-  dtostrf((atof(gasReceived5min) - atof(log_data.dayG)), 6, 2, value);
+  dtostrf((dsmrData.gas_delivered.toFloat() - atof(log_data.dayG)), 6, 2, value);
   sprintf(buffer, "['%s', %s],\n", string2char(str), value);
   appendFile("/MonthsG.log", buffer);
   strcpy(log_data.monthG, value);
@@ -459,10 +458,10 @@ void resetEnergyDaycount() {
   strcpy(log_data.dayR1, cumulativeActiveExport);
   strcpy(log_data.dayR2, cumulativeReactiveExport);
 #else
-  strcpy(log_data.dayE1, electricityUsedTariff1);
-  strcpy(log_data.dayE2, electricityUsedTariff2);
-  strcpy(log_data.dayR1, electricityReturnedTariff1);
-  strcpy(log_data.dayR2, electricityReturnedTariff2);
+  strcpy(log_data.dayE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.dayE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.dayR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.dayR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 #endif
   coldbootE = false;
 }
@@ -474,15 +473,15 @@ void resetEnergyMonthcount() {
   strcpy(log_data.monthR1, cumulativeActiveExport);
   strcpy(log_data.monthR2, cumulativeReactiveExport);
 #else
-  strcpy(log_data.monthE1, electricityUsedTariff1);
-  strcpy(log_data.monthE2, electricityUsedTariff2);
-  strcpy(log_data.monthR1, electricityReturnedTariff1);
-  strcpy(log_data.monthR2, electricityReturnedTariff2);
+  strcpy(log_data.monthE1, String(dsmrData.energy_delivered_tariff1.val()).c_str());
+  strcpy(log_data.monthE2, String(dsmrData.energy_delivered_tariff2.val()).c_str());
+  strcpy(log_data.monthR1, String(dsmrData.energy_returned_tariff1.val()).c_str());
+  strcpy(log_data.monthR2, String(dsmrData.energy_returned_tariff2.val()).c_str());
 #endif
 }
 
 void resetGasCount() {
-  strcpy(log_data.dayG, gasReceived5min);
+  strcpy(log_data.dayG, dsmrData.gas_delivered.c_str());
   coldbootG = false;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,10 +206,6 @@ const char *host = "P1wifi";
     return;                                                                    \
   }
 
-#define NUM(off, mult)                                                         \
-  ((P1timestamp[(off)] - '0') *                                                \
-   (mult)) // macro for getting time out of timestamp, see decoder
-
 #include "lang.h"
 #include "vars.h"
 #include "led.h"

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -18,7 +18,6 @@ void RTS_on();
 void RTS_off();
 bool isNumber(char *res, int len);
 int FindCharInArray(char array[], char c, int len);
-void settime();
 String timestamp();
 String timestampkaal();
 void timeIsSet_cb();

--- a/src/vars.h
+++ b/src/vars.h
@@ -1,3 +1,5 @@
+#include <WString.h>
+
 /*
  * vars.h
  */
@@ -28,76 +30,89 @@ bool bootSetup = false; // flag for adminpassword bypass
 bool AdminAuthenticated = false;
 char setupToken[18];
 
+// Value that is parsed as a three-decimal float, but stored as an
+// integer (by multiplying by 1000). Supports val() (or implicit cast to
+// float) to get the original value, and int_val() to get the more
+// efficient integer value. The unit() and int_unit() methods on
+// FixedField return the corresponding units for these values.
+struct FixedValue {
+  FixedValue() {
+    _value = 0;
+  }
+  FixedValue(String value) {
+    _value = value.toFloat() * 1000;
+  }
+  operator float() { return val(); }
+  float val() { return _value / 1000.0; }
+  uint32_t int_val() { return _value; }
+
+  uint32_t _value{0};
+};
+
 // Vars to store meter readings
 // we capture all data in char arrays or Strings for longer hard to delineate
 // data
-String P1header;
-char P1version[8];
-int P1prot; // 4 or 5 based on P1version 1-3:0.2.8
-char P1timestamp[30] = "\0";
-char equipmentId[100] = "\0";
-char equipmentId2[100] = "\0";
-char electricityUsedTariff1[12];
-char electricityUsedTariff2[12];
-char electricityReturnedTariff1[12];
-char electricityReturnedTariff2[12];
-char tariffIndicatorElectricity[8];
-char numberPowerFailuresAny[6];
-char numberLongPowerFailuresAny[6];
-String longPowerFailuresLog;
-char numberVoltageSagsL1[7];
-char numberVoltageSagsL2[7];
-char numberVoltageSagsL3[7];
-char numberVoltageSwellsL1[7];
-char numberVoltageSwellsL2[7];
-char numberVoltageSwellsL3[7];
-String textMessage;
-char instantaneousVoltageL1[7];
-char instantaneousVoltageL2[7];
-char instantaneousVoltageL3[7];
-char instantaneousCurrentL1[9];
-char instantaneousCurrentL2[9];
-char instantaneousCurrentL3[9];
-char activePowerL1P[10];
-char activePowerL2P[10];
-char activePowerL3P[10];
-char activePowerL1NP[10];
-char activePowerL2NP[10];
-char activePowerL3NP[10];
-char actualElectricityPowerDeli[14];
-char actualElectricityPowerRet[14];
+struct DSMRData {
+  // String identification;
+  String p1_version;                   // P1version
+  String timestamp;                    // P1timestamp
+  String equipment_id;                 // equipmentId
+  FixedValue energy_delivered_tariff1; // electricityUsedTariff1
+  FixedValue energy_delivered_tariff2; // electricityUsedTariff2
+  FixedValue energy_returned_tariff1;  // electricityReturnedTariff1
+  FixedValue energy_returned_tariff2;  // electricityReturnedTariff2
+  String electricity_tariff;           // tariffIndicatorElectricity
+  FixedValue power_delivered;          // actualElectricityPowerDeli
+  FixedValue power_returned;           // actualElectricityPowerRet
+  // FixedValue electricity_threshold;
+  // uint8_t electricity_switch_position;
+  uint32_t electricity_failures;      // numberPowerFailuresAny
+  uint32_t electricity_long_failures; // numberLongPowerFailuresAny
+  String electricity_failure_log;     // longPowerFailuresLog
+  uint32_t electricity_sags_l1;       // numberVoltageSagsL1
+  uint32_t electricity_sags_l2;       // numberVoltageSagsL2
+  uint32_t electricity_sags_l3;       // numberVoltageSagsL3
+  uint32_t electricity_swells_l1;     // numberVoltageSwellsL1
+  uint32_t electricity_swells_l2;     // numberVoltageSwellsL2
+  uint32_t electricity_swells_l3;     // numberVoltageSwellsL3
+  // String message_short;
+  // String message_long;
+  FixedValue voltage_l1;         // instantaneousVoltageL1
+  FixedValue voltage_l2;         // instantaneousVoltageL2
+  FixedValue voltage_l3;         // instantaneousVoltageL3
+  FixedValue current_l1;         // instantaneousCurrentL1
+  FixedValue current_l2;         // instantaneousCurrentL2
+  FixedValue current_l3;         // instantaneousCurrentL3
+  FixedValue power_delivered_l1; // activePowerL1P
+  FixedValue power_delivered_l2; // activePowerL2P
+  FixedValue power_delivered_l3; // activePowerL3P
+  FixedValue power_returned_l1;  // activePowerL1NP
+  FixedValue power_returned_l2;  // activePowerL2NP
+  FixedValue power_returned_l3;  // activePowerL3NP
 
-// // Swedish specific
-// char cumulativeActiveImport[12];    // 1.8.0
-// char cumulativeActiveExport[12];    // 2.8.0
-// char cumulativeReactiveImport[12];  // 3.8.0
-// char cumulativeReactiveExport[12];  // 4.8.0
-// char momentaryActiveImport[12];     // 1.7.0
-// char momentaryActiveExport[12];     // 2.7.0
-// char momentaryReactiveImport[12];   // 3.7.0
-// char momentaryReactiveExport[12];   // 4.7.0
-// char momentaryReactiveImportL1[12]; // 23.7.0
-// char momentaryReactiveImportL2[12]; // 43.7.0
-// char momentaryReactiveImportL3[12]; // 63.7.0
-// char momentaryReactiveExportL1[12]; // 24.7.0
-// char momentaryReactiveExportL2[12]; // 44.7.0
-// char momentaryReactiveExportL3[12]; // 64.7.0
+  // uint16_t gas_device_type;
+  String gas_equipment_id; // equipmentId2
+  // uint8_t gas_valve_position;
+  String gas_delivered; // gasReceived5min
 
-// char reactivePowerL1P[9]; // Sweden uses these 6
-// char reactivePowerL2P[9];
-// char reactivePowerL3P[9];
-// char reactivePowerL1NP[9];
-// char reactivePowerL2NP[9];
-// char reactivePowerL3NP[9];
+  // uint16_t thermal_device_type;
+  // String thermal_equipment_id;
+  // uint8_t thermal_valve_position;
+  // String thermal_delivered;
 
-// end Swedish
-char deviceType[5];
-char gasId[100] = "\0";
-;
-char gasReceived5min[12];
-char gasDomoticz[12]; // Domoticz wil gas niet in decimalen?
+  // uint16_t water_device_type;
+  // String water_equipment_id;
+  // uint8_t water_valve_position;
+  // String water_delivered;
+  // uint16_t sub_device_type;
+  // String sub_equipment_id;
+  // uint8_t sub_valve_position;
+  // String sub_delivered;
 
-char prevGAS[12]; // not an P1 protocol var, but holds gas value
+  uint8_t P1prot() { return p1_version[0] == '4' ? 4 : 5; }
+} dsmrData;
+
+String prevGAS; // not an P1 protocol var, but holds gas value
 
 // logging vars
 byte logFlags;

--- a/src/webserverNL.h
+++ b/src/webserverNL.h
@@ -128,9 +128,9 @@ void handleSetup() {
 
 void handleP1() {
   Log.verbose("handleP1: actualElectricityPowerRet: ");
-  Log.verboseln(actualElectricityPowerRet);
+  Log.verboseln("%F", dsmrData.power_returned.val());
   Log.verbose("handleP1: actualElectricityPowerDeli: ");
-  Log.verboseln(actualElectricityPowerDeli);
+  Log.verboseln("%F", dsmrData.power_delivered.val());
   Log.verboseln("handleP1");
   String str = "";
   String eenheid, eenheid2, eenheid3;
@@ -152,110 +152,110 @@ void handleP1() {
 
   str += "<p><div class='row'><div class='column'><b>Verbruik laag tarief: "
          "totaal</b><input type='text' class='form-control c6' value='";
-  str += electricityUsedTariff1;
+  str += String(dsmrData.energy_delivered_tariff1);
   str += eenheid;
   str += "<div class='column' style='text-align:right'><b>vandaag</b><input "
          "type='text' class='form-control c7' value='";
-  str += atof(electricityUsedTariff1) - atof(log_data.dayE1);
+  str += dsmrData.energy_delivered_tariff1.val() - atof(log_data.dayE1);
   str += eenheid;
   str += "</div></p>";
 
   str += "<p><div class='row'><div class='column'><b>Verbruik hoog tarief: "
          "totaal</b><input type='text' class='form-control c6' value='";
-  str += electricityUsedTariff2;
+  str += String(dsmrData.energy_delivered_tariff2);
   str += eenheid;
   str += "<div class='column' style='text-align:right'><b>vandaag</b><input "
          "type='text' class='form-control c7' value='";
-  str += atof(electricityUsedTariff2) - atof(log_data.dayE2);
+  str += dsmrData.energy_delivered_tariff2.val() - atof(log_data.dayE2);
   str += eenheid;
   str += "</div></p>";
 
   str += "<p><div class='row'><div class='column'><b>Retour laag tarief: "
          "totaal</b><input type='text' class='form-control c6' value='";
-  str += electricityReturnedTariff1;
+  str += String(dsmrData.energy_returned_tariff1);
   str += eenheid;
   str += "<div class='column' style='text-align:right'><b>vandaag</b><input "
          "type='text' class='form-control c7' value='";
-  str += atof(electricityReturnedTariff1) - atof(log_data.dayR1);
+  str += dsmrData.energy_returned_tariff1.val() - atof(log_data.dayR1);
   str += eenheid;
   str += "</div></p>";
 
   str += "<p><div class='row'><div class='column'><b>Retour hoog tarief: "
          "totaal</b><input type='text' class='form-control c6' value='";
-  str += electricityReturnedTariff2;
+  str += String(dsmrData.energy_returned_tariff2);
   str += eenheid;
   str += "<div class='column' style='text-align:right'><b>vandaag</b><input "
          "type='text' class='form-control c7' value='";
-  str += atof(electricityReturnedTariff2) - atof(log_data.dayR2);
+  str += dsmrData.energy_returned_tariff2.val() - atof(log_data.dayR2);
   str += eenheid;
   str += "</div></p>";
 
   Log.verbose("buildpage: actualElectricityPowerRet: ");
-  Log.verboseln(actualElectricityPowerRet);
+  Log.verboseln("%F", dsmrData.power_returned.val());
   Log.verbose("handleP1: actualElectricityPowerDeli: ");
-  Log.verboseln(actualElectricityPowerDeli);
+  Log.verboseln("%F", dsmrData.power_delivered.val());
 
   str += "<p><div class='row'><b>Actueel verbruik</b><input type='text' "
          "class='form-control c6' value='";
-  str += actualElectricityPowerDeli;
+  str += String(dsmrData.power_delivered.val());
   str += eenheid2;
 
   str += "<p><div class='row'><b>Actueel retour</b><input type='text' "
          "class='form-control c6' value='";
-  str += actualElectricityPowerRet;
+  str += String(dsmrData.power_returned.val());;
   str += eenheid2;
 
-  if (P1prot == 5) {
+  if (dsmrData.P1prot() == 5) {
     str += "<p><div class='row'><div class='column3'><b>Voltage: L1</b><input "
            "type='text' class='form-control c6' value='";
-    str += instantaneousVoltageL1;
+    str += String(dsmrData.voltage_l1.val());
     str += " V'></div>";
     str += "<div class='column3' style='text-align:right'><b>L2</b><input "
            "type='text' class='form-control c7' value='";
-    str += instantaneousVoltageL2;
+    str += String(dsmrData.voltage_l2.val());
     str += " V'></div>";
     str += "<div class='column3' style='text-align:right'><b>L3</b><input "
            "type='text' class='form-control c7' value='";
-    str += instantaneousVoltageL3;
+    str += String(dsmrData.voltage_l3.val());
     str += " V'></div></div></p>";
 
     str += "<p><div class='row'><div class='column3'><b>Verbruik: L1</b><input "
            "type='text' class='form-control c6' value='";
-    str += activePowerL1P;
+    str += String(dsmrData.power_delivered_l1.val());
     str += " kW'></div>";
     str += "<div class='column3' style='text-align:right'><b>L2</b><input "
            "type='text' class='form-control c7' value='";
-    str += activePowerL2P;
+    str += String(dsmrData.power_delivered_l2.val());
     str += " kW'></div>";
     str += "<div class='column3' style='text-align:right'><b>L3</b><input "
            "type='text' class='form-control c7' value='";
-    str += activePowerL3P;
+    str += String(dsmrData.power_delivered_l3.val());
     str += " kW'></div></div></p>";
 
     str += "<p><div class='row'><div class='column3'><b>Retour: L1</b><input "
            "type='text' class='form-control c6' value='";
-    str += activePowerL1NP;
+    str += String(dsmrData.power_returned_l1.val());
     str += " kW'></div>";
     str += "<div class='column3' style='text-align:right'><b>L2</b><input "
            "type='text' class='form-control c7' value='";
-    str += activePowerL2NP;
+    str += String(dsmrData.power_returned_l2.val());
     str += " kW'></div>";
     str += "<div class='column3' style='text-align:right'><b>L3</b><input "
            "type='text' class='form-control c7' value='";
-    str += activePowerL3NP;
+    str += String(dsmrData.power_returned_l3.val());
     str += " kW'></div></div></p>";
   }
   str += "<p><div class='row'><div class='column3'><b>Amperage: L1</b><input "
          "type='text' class='form-control c6' value='";
-  str += instantaneousCurrentL1;
+  str += String(dsmrData.current_l1.val());
   str += " A'></div>";
   str += "<div class='column3' style='text-align:right'><b>L2</b><input "
          "type='text' class='form-control c7' value='";
-  str += instantaneousCurrentL2;
+  str += String(dsmrData.current_l2.val());
   str += " A'></div>";
   str += "<div class='column3' style='text-align:right'><b>L3</b><input "
          "type='text' class='form-control c7' value='";
-  str += instantaneousCurrentL3;
+  str += String(dsmrData.current_l3.val());
   str += " A'></div></div></p>";
   /*
 
@@ -270,11 +270,11 @@ void handleP1() {
     */
   str += "<p><div class='row'><div class='column'><b>Gasverbruik: "
          "totaal</b><input type='text' class='form-control c6' value='";
-  str += gasReceived5min;
+  str += dsmrData.gas_delivered;
   str += F(" m3'></div>");
   str += "<div class='column' style='text-align:right'><b>vandaag</b><input "
          "type='text' class='form-control c7' value='";
-  str += atof(gasReceived5min) - atof(log_data.dayG);
+  str += dsmrData.gas_delivered.toFloat() - atof(log_data.dayG);
   str += " m3'></div></div></p>";
   str += F("</fieldset></form>");
   str += F("<form action='/' method='POST'><button class='button "


### PR DESCRIPTION
Moved all P1 reading variables to a single `struct`. This allows new code to reference the struct instead of all the single variables.
Also changed some P1 variables from char to int/float to better represent the value.

Removed `settime` method and `NUM` definition since it was not used anymore.